### PR TITLE
Fix s medal door

### DIFF
--- a/worlds/animal_well/client.py
+++ b/worlds/animal_well/client.py
@@ -1132,8 +1132,8 @@ class AWItems:
                         (str(flags >> 12 & 1)) +  # Chameleon Defeated
                         (str(flags >> 13 & 1)) +  # C Ring Collected
                         (str(flags >> 14 & 1)) +  # Eaten By Chameleon
-                        ("1" if inserted_s_medal == 2 else "0") +  # Inserted S Medal
-                        ("1" if inserted_e_medal == 2 else "0") +  # Inserted E Medal
+                        ("1" if inserted_s_medal else "0") +  # Inserted S Medal
+                        ("1" if inserted_e_medal else "0") +  # Inserted E Medal
                         (str(flags >> 17 & 1)) +  # Wings Acquired
                         (str(flags >> 18 & 1)) +  # Woke Up
                         ("1" if self.bubble > 1 else "0") +  # B.B. Wand Upgrade


### PR DESCRIPTION
Fix the s medal door closing behind you. It was being added back to the inventory and removed from the door whenever you placed it.

Made the same change for the e medal since I figured it would probably encounter the same issue.