### PR TITLE
Added a new pointer-based approach for finding base memory location

### DIFF
--- a/worlds/animal_well/client.py
+++ b/worlds/animal_well/client.py
@@ -809,7 +809,7 @@ async def get_animal_well_process_handle(ctx: AnimalWellContext):
             logger.info("Searching for 'Animal Well.exe' module in process memory...")
             awModule = next(f for f in list(process_handle.list_modules()) if f.name.startswith("Animal Well.exe"))
             if awModule:
-                logger.info("Found it: Name(%s), EntryPoint(%s), BaseOfDll(%s)", awModule.name, hex(awModule.EntryPoint), hex(awModule.lpBaseOfDll))
+                logger.info("Found it: Name(%s), BaseOfDll(%s)", awModule.name, hex(awModule.EntryPoint), hex(awModule.lpBaseOfDll))
 
                 pointerAddress = awModule.lpBaseOfDll + 0x02BD5308
                 logger.info("Attempting to find start address via pointer at %s", hex(pointerAddress))

--- a/worlds/animal_well/client.py
+++ b/worlds/animal_well/client.py
@@ -809,7 +809,7 @@ async def get_animal_well_process_handle(ctx: AnimalWellContext):
             logger.info("Searching for 'Animal Well.exe' module in process memory...")
             awModule = next(f for f in list(process_handle.list_modules()) if f.name.startswith("Animal Well.exe"))
             if awModule:
-                logger.info("Found it: Name(%s), BaseOfDll(%s)", awModule.name, hex(awModule.EntryPoint), hex(awModule.lpBaseOfDll))
+                logger.info("Found it: Name(%s), BaseOfDll(%s)", awModule.name, hex(awModule.lpBaseOfDll))
 
                 pointerAddress = awModule.lpBaseOfDll + 0x02BD5308
                 logger.info("Attempting to find start address via pointer at %s", hex(pointerAddress))

--- a/worlds/animal_well/client.py
+++ b/worlds/animal_well/client.py
@@ -842,9 +842,9 @@ async def get_animal_well_process_handle(ctx: AnimalWellContext):
                             hex(max_length))
 
                 # Preprocess
-                m = len(pattern)
+                patternLength = len(pattern)
                 bad_chars = [-1] * 256
-                for i in range(m):
+                for i in range(patternLength):
                     bad_chars[pattern[i]] = i
 
                 # Search
@@ -858,7 +858,7 @@ async def get_animal_well_process_handle(ctx: AnimalWellContext):
                         if iterations % 0x80000 == 0:
                             logger.info("Looking for start address of memory, %s", hex(address))
 
-                        i = m - 1
+                        i = patternLength - 1
 
                         while i >= 0 and pattern[i] == process_handle.read_bytes(address + i, 1)[0]:
                             i -= 1
@@ -882,9 +882,6 @@ async def get_animal_well_process_handle(ctx: AnimalWellContext):
 
             ctx.process_handle = process_handle
             ctx.start_address = address
-
-
-            #ctypes.windll.user32.MessageBoxW(0, "Your text", "Your title", 1)
         else:
             raise NotImplementedError("Only Windows is implemented right now")
     except pymem.exception.ProcessNotFound as e:


### PR DESCRIPTION
## What is this fixing or adding?
Adds a new method for determining the base memory location in Animal Well's client by looking at an unmoving pointer that always points to the location (-0x400) that we're searching for with the existing method. If this method fails, the process falls back on the current method of comparing save-file data to memory. I'd like to eventually add some additional checks to confirm that the location found from either method is correct, maybe comparing a few bytes we expect to always be in the same place and order to a known set of bytes.

## How was this tested?
Ran the Animal Well client several times and it worked every time I tested. Additionally did some play-testing to ensure it wasn't just APPEARING to work.

## If this makes graphical changes, please attach screenshots.
