### PR TITLE
animal_well: Bounds check berries and firecrackers

### DIFF
--- a/worlds/animal_well/client.py
+++ b/worlds/animal_well/client.py
@@ -783,7 +783,7 @@ class AWItems:
                     if not ctx.used_berries:
                         ctx.used_berries = 0
 
-                    berries_to_use = self.big_blue_fruit - ctx.used_berries
+                    berries_to_use = max(self.big_blue_fruit - ctx.used_berries, 0)
                     total_hearts = int.from_bytes(ctx.process_handle.read_bytes(slot_address + 0x1B4, 1),
                                                   byteorder="little")
                     # berries_to_use multiplied by 3 to always give you +3 hearts
@@ -809,7 +809,7 @@ class AWItems:
                     if not ctx.used_firecrackers:
                         ctx.used_firecrackers = 0
 
-                    firecrackers_to_use = self.firecracker_refill - ctx.used_firecrackers
+                    firecrackers_to_use = max(self.firecracker_refill - ctx.used_firecrackers, 0)
                     total_firecrackers = int.from_bytes(ctx.process_handle.read_bytes(slot_address + 0x1B3, 1),
                                                         byteorder="little")
                     # multiply firecrackers to use by 6 so that it always fills up your inventory

--- a/worlds/animal_well/client.py
+++ b/worlds/animal_well/client.py
@@ -6,6 +6,7 @@ Based (read: copied almost wholesale and edited) off the Zelda1 Client.
 import asyncio
 import os
 import platform
+import traceback
 
 import pymem
 
@@ -96,18 +97,22 @@ class AnimalWellCommandProcessor(ClientCommandProcessor):
         except pymem.exception.ProcessError as e:
             logger.error("%s", e)
             self.ctx.connection_status = CONNECTION_RESET_STATUS
+            traceback.print_exc()
             logger.info(f"Animal Well Connection Status: {self.ctx.connection_status}")
         except pymem.exception.MemoryReadError as e:
             logger.error("%s", e)
             self.ctx.connection_status = CONNECTION_RESET_STATUS
+            traceback.print_exc()
             logger.info(f"Animal Well Connection Status: {self.ctx.connection_status}")
         except pymem.exception.MemoryWriteError as e:
             logger.error("%s", e)
             self.ctx.connection_status = CONNECTION_RESET_STATUS
+            traceback.print_exc()
             logger.info(f"Animal Well Connection Status: {self.ctx.connection_status}")
         except Exception as e:
             logger.fatal("An unknown error has occurred: %s", e)
             self.ctx.connection_status = CONNECTION_ABORTED_STATUS
+            traceback.print_exc()
             logger.info(f"Animal Well Connection Status: {self.ctx.connection_status}")
 
 
@@ -224,22 +229,27 @@ class AWLocations:
         except pymem.exception.ProcessError as e:
             logger.error("%s", e)
             ctx.connection_status = CONNECTION_RESET_STATUS
+            traceback.print_exc()
             logger.info(f"Animal Well Connection Status: {ctx.connection_status}")
         except pymem.exception.MemoryReadError as e:
             logger.error("%s", e)
             ctx.connection_status = CONNECTION_RESET_STATUS
+            traceback.print_exc()
             logger.info(f"Animal Well Connection Status: {ctx.connection_status}")
         except ConnectionResetError as e:
             logger.error("%s", e)
             ctx.connection_status = CONNECTION_RESET_STATUS
+            traceback.print_exc()
             logger.info(f"Animal Well Connection Status: {ctx.connection_status}")
         except NotImplementedError as e:
             logger.fatal("%s", e)
             ctx.connection_status = CONNECTION_ABORTED_STATUS
+            traceback.print_exc()
             logger.info(f"Animal Well Connection Status: {ctx.connection_status}")
         except Exception as e:
             logger.fatal("An unknown error has occurred: %s", e)
             ctx.connection_status = CONNECTION_ABORTED_STATUS
+            traceback.print_exc()
             logger.info(f"Animal Well Connection Status: {ctx.connection_status}")
 
     async def write_to_archipelago(self, ctx):
@@ -268,6 +278,7 @@ class AWLocations:
         except Exception as e:
             logger.fatal("An unknown error has occurred: %s", e)
             ctx.connection_status = CONNECTION_ABORTED_STATUS
+            traceback.print_exc()
             logger.info(f"Animal Well Connection Status: {ctx.connection_status}")
 
 
@@ -528,6 +539,7 @@ class AWItems:
         except Exception as e:
             logger.fatal("An unknown error has occurred: %s", e)
             ctx.connection_status = CONNECTION_ABORTED_STATUS
+            traceback.print_exc()
             logger.info(f"Animal Well Connection Status: {ctx.connection_status}")
 
     def write_to_game(self, ctx):
@@ -825,26 +837,32 @@ class AWItems:
         except pymem.exception.ProcessError as e:
             logger.error("%s", e)
             ctx.connection_status = CONNECTION_RESET_STATUS
+            traceback.print_exc()
             logger.info(f"Animal Well Connection Status: {ctx.connection_status}")
         except pymem.exception.MemoryReadError as e:
             logger.error("%s", e)
             ctx.connection_status = CONNECTION_RESET_STATUS
+            traceback.print_exc()
             logger.info(f"Animal Well Connection Status: {ctx.connection_status}")
         except pymem.exception.MemoryWriteError as e:
             logger.error("%s", e)
             ctx.connection_status = CONNECTION_RESET_STATUS
+            traceback.print_exc()
             logger.info(f"Animal Well Connection Status: {ctx.connection_status}")
         except ConnectionResetError as e:
             logger.error("%s", e)
             ctx.connection_status = CONNECTION_RESET_STATUS
+            traceback.print_exc()
             logger.info(f"Animal Well Connection Status: {ctx.connection_status}")
         except NotImplementedError as e:
             logger.fatal("%s", e)
             ctx.connection_status = CONNECTION_ABORTED_STATUS
+            traceback.print_exc()
             logger.info(f"Animal Well Connection Status: {ctx.connection_status}")
         except Exception as e:
             logger.fatal("An unknown error has occurred: %s", e)
             ctx.connection_status = CONNECTION_ABORTED_STATUS
+            traceback.print_exc()
             logger.info(f"Animal Well Connection Status: {ctx.connection_status}")
 
 
@@ -940,30 +958,37 @@ async def get_animal_well_process_handle(ctx: AnimalWellContext):
     except pymem.exception.ProcessNotFound as e:
         logger.error("%s", e)
         ctx.connection_status = CONNECTION_REFUSED_STATUS
+        traceback.print_exc()
         logger.info(f"Animal Well Connection Status: {ctx.connection_status}")
     except pymem.exception.CouldNotOpenProcess as e:
         logger.error("%s", e)
         ctx.connection_status = CONNECTION_REFUSED_STATUS
+        traceback.print_exc()
         logger.info(f"Animal Well Connection Status: {ctx.connection_status}")
     except pymem.exception.ProcessError as e:
         logger.error("%s", e)
         ctx.connection_status = CONNECTION_REFUSED_STATUS
+        traceback.print_exc()
         logger.info(f"Animal Well Connection Status: {ctx.connection_status}")
     except pymem.exception.MemoryReadError as e:
         logger.error("%s", e)
         ctx.connection_status = CONNECTION_REFUSED_STATUS
+        traceback.print_exc()
         logger.info(f"Animal Well Connection Status: {ctx.connection_status}")
     except FileNotFoundError as e:
         logger.fatal("%s", e)
         ctx.connection_status = CONNECTION_ABORTED_STATUS
+        traceback.print_exc()
         logger.info(f"Animal Well Connection Status: {ctx.connection_status}")
     except NotImplementedError as e:
         logger.fatal("%s", e)
         ctx.connection_status = CONNECTION_ABORTED_STATUS
+        traceback.print_exc()
         logger.info(f"Animal Well Connection Status: {ctx.connection_status}")
     except Exception as e:
         logger.fatal("An unknown error has occurred: %s", e)
         ctx.connection_status = CONNECTION_ABORTED_STATUS
+        traceback.print_exc()
         logger.info(f"Animal Well Connection Status: {ctx.connection_status}")
 
 

--- a/worlds/animal_well/client.py
+++ b/worlds/animal_well/client.py
@@ -783,6 +783,7 @@ class AWItems:
                     if not ctx.used_berries:
                         ctx.used_berries = 0
 
+                    # sometimes used_berries ends up bigger than big_blue_fruit, same with firecrackers
                     berries_to_use = max(self.big_blue_fruit - ctx.used_berries, 0)
                     total_hearts = int.from_bytes(ctx.process_handle.read_bytes(slot_address + 0x1B4, 1),
                                                   byteorder="little")


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?

self.big_blue_fruit and self.firecracker_refill might be 0,
which would make berries_to_use/firecrackers_to_use go
negative. To fix this, do a `max(self.big_blue_fruit - ctx.used_berries, 0)` to
bounds check it and set to 0 if otherwise negative

## How was this tested?

Tested in affected multiworld

## If this makes graphical changes, please attach screenshots.
