### PR TITLE
Discord logic updates as of 7/14/24 + some well drop fixes

### DIFF
--- a/worlds/animal_well/region_data.py
+++ b/worlds/animal_well/region_data.py
@@ -184,7 +184,7 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         lname.egg_normal:  # hidden wall in lower left of first bubble room
             AWData(AWType.location),
         lname.egg_dazzle:  # little obstacle course, feels like the bubble jump tutorial?
-            AWData(AWType.location, [[iname.bubble], [iname.disc, iname.wheel]]),
+            AWData(AWType.location, [[iname.bubble], [iname.disc, iname.wheel], [iname.disc_hop_hard]]),
         rname.fish_tube_room:  # enter at the save room fish pipe, the rooms with all the fish pipes
             AWData(AWType.region, [[iname.bubble]]),
         lname.egg_sunset:  # break the spikes in the room to the right of the fish warp
@@ -211,7 +211,8 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
                                      [iname.wheel_hard], [iname.bubble, iname.disc]]),
         rname.fish_lower:  # bubble to go down, activate switches, breakspike to pass icicles in first penguin room
             AWData(AWType.region, [[iname.bubble, iname.remote, iname.can_break_spikes],
-                                   [iname.remote, iname.wheel_hard], [iname.bubble, iname.disc]]),
+                                   [iname.remote, iname.wheel_hard], [iname.disc, iname.wheel_hard, iname.weird_tricks]  # throwing disc to hit switch while wheel stalling is very tight
+                                   [iname.bubble, iname.disc]]),
         lname.activate_fish_fast_travel:  # vertical implied by access
             AWData(AWType.location, [[iname.flute]], event=iname.activated_fish_fast_travel),
         rname.fast_travel:  # vertical implied by access
@@ -439,7 +440,7 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         rname.match_center_well_spot:
             AWData(AWType.region),  # wall is flush, just hold left
         rname.bear_truth_egg_spot:
-            AWData(AWType.region, [[iname.wheel_hard]]),
+            AWData(AWType.region, [[iname.wheel_hard], [iname.bubble, iname.weird_tricks]]),
         # top_of_the_well:  # unnecessary because of the connection from match center spot
         #     AWData(AWType.region, [[iname.bubble_long]]),
         rname.bear_upper_phone_room:
@@ -928,13 +929,13 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         lname.egg_pickled:  # hold right while falling down the well
             AWData(AWType.location),
         rname.chocolate_egg_spot:
-            AWData(AWType.region, [[iname.bubble]]),  # wall juts out, need bubble
+            AWData(AWType.region, [[iname.wheel_hard], [iname.bubble]]),  # wall juts out, need bubble
         rname.match_center_well_spot:
             AWData(AWType.region),  # wall is flush, just hold left
         rname.bear_match_chest_spot:
-            AWData(AWType.region, [[iname.wheel_hard]]),
+            AWData(AWType.region, [[iname.wheel_hard], [iname.bubble]]),
         rname.bear_truth_egg_spot:
-            AWData(AWType.region, [[iname.wheel_hard]]),
+            AWData(AWType.region, [[iname.wheel_hard], [iname.bubble, iname.weird_tricks]]),
     },
     rname.chocolate_egg_spot: {
         lname.egg_chocolate:  # across from center well match
@@ -946,7 +947,7 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         rname.top_of_the_well:
             AWData(AWType.region, [[iname.bubble_long], [iname.wheel_hard]]),
         rname.bear_truth_egg_spot:
-            AWData(AWType.region, [[iname.wheel_hard]]),
+            AWData(AWType.region, [[iname.wheel_hard], [iname.bubble, iname.weird_tricks]]),
     },
     rname.match_center_well_spot: {
         lname.match_center_well:  # across from the chocolate egg
@@ -958,7 +959,7 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         rname.top_of_the_well:
             AWData(AWType.region, [[iname.bubble_long], [iname.wheel_hard]]),
         rname.bear_truth_egg_spot:
-            AWData(AWType.region, [[iname.wheel_hard]]),
+            AWData(AWType.region, [[iname.wheel_hard], [iname.bubble, iname.weird_tricks]]),
     },
 
     rname.fast_travel: {

--- a/worlds/animal_well/region_data.py
+++ b/worlds/animal_well/region_data.py
@@ -440,6 +440,7 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         rname.match_center_well_spot:
             AWData(AWType.region),  # wall is flush, just hold left
         rname.bear_truth_egg_spot:
+            # fall down the shaft, catch yourself on a bubble, and jump right quickly before the bird pops it
             AWData(AWType.region, [[iname.wheel_hard], [iname.bubble, iname.weird_tricks]]),
         # top_of_the_well:  # unnecessary because of the connection from match center spot
         #     AWData(AWType.region, [[iname.bubble_long]]),

--- a/worlds/animal_well/region_data.py
+++ b/worlds/animal_well/region_data.py
@@ -211,7 +211,7 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
                                      [iname.wheel_hard], [iname.bubble, iname.disc]]),
         rname.fish_lower:  # bubble to go down, activate switches, breakspike to pass icicles in first penguin room
             AWData(AWType.region, [[iname.bubble, iname.remote, iname.can_break_spikes],
-                                   [iname.remote, iname.wheel_hard], [iname.disc, iname.wheel_hard, iname.weird_tricks]  # throwing disc to hit switch while wheel stalling is very tight
+                                   [iname.remote, iname.wheel_hard], [iname.disc, iname.wheel_hard, iname.weird_tricks],  # throwing disc to hit switch while wheel stalling is very tight
                                    [iname.bubble, iname.disc]]),
         lname.activate_fish_fast_travel:  # vertical implied by access
             AWData(AWType.location, [[iname.flute]], event=iname.activated_fish_fast_travel),


### PR DESCRIPTION
Cleared out all logical considerations raised in the AP Discord thread as of today.

1) Dazzle Egg with Disc_hard: Proven to be very doable within the speedruns, no reason why it can't be logical.

2) Truth Egg spot from well drop with bubble only: Annoying, but doable, and not particularly tight. Particularly punishing if your logical access to the well drop is through bear area and not through flute warp, since the walk back up takes forever. Keep it as a weird trick for now.

3) Slink Chest not in logic with yoyo + top: Appears to be a tracker bug. No changes.

`bear_area_entry to bear_kangaroo_waterfall with top + yoyo, to bear_ladder_after_chameleon with nothing, to bear_slink_room with nothing, has location slink_chest with no requirements
`

4) Fish West to Fish Lower with wheel_hard + disc. Ew. Doable: I replicated it myself twice after several failed attempts. I'm sure there's a way to get consistent by getting a feel for the timing. I don't like this trick. I feel like if we're going to do difficulty categories in the future, this needs to be in one of the hardest ones. But here it is for now!

Additionally, while testing the Truth egg trick, I noticed that there were several connections in the well drop that did not consider simply riding a bubble down as a valid connection path. This has been remedied.
