### PR TITLE
ANIMAL WELL: Fix Mock Disc inventory and chest, add patch to skip credits

### DIFF
--- a/worlds/animal_well/client.py
+++ b/worlds/animal_well/client.py
@@ -882,6 +882,11 @@ class AWItems:
                 flags = int.from_bytes(ctx.process_handle.read_bytes(slot_address + 0x1DE, 1), byteorder="little")
                 possess_m_disc = self.m_disc and (bool(flags >> 0 & 1) or ctx.first_m_disc)
                 if self.m_disc:
+                    if ctx.first_m_disc:
+                        quest = int.from_bytes(ctx.process_handle.read_bytes(slot_address + 0x1EC, 8), byteorder="little")
+                        quest |= 0x60000000
+                        buffer = quest.to_bytes(8, byteorder="little")
+                        ctx.process_handle.write_bytes(slot_address + 0x1EC, buffer, 8)
                     ctx.first_m_disc = False
 
                 # Write Other Items


### PR DESCRIPTION
## What is this fixing or adding?

### Fix Mock Disc in inventory and the chest appearing closed

When receiving for the first time, also sets the two Mock Disc related bits in the quest progression, so the inventory and Mock Disc Chest know you have it. This should fix the problem of not knowing you had the disc all along, if you missed the message and haven't tried to interact with the shrines yet.

### Skip credits

Adds patch to skip credits and drop the house key instantly on the detonator. Credits are annoying and make you wait 2 minutes to finish the goal or continue the game. Now you can choose to watch the manticore get dazzled up or just leave/quit.

## How was this tested?

Very briefly by noclipping to the hinted Mock Disc location, the Mock Disc Chest and then to the fireworks, which all seemed to work great.