### PR TITLE
Factor out weird_tricks

### DIFF
--- a/worlds/animal_well/names.py
+++ b/worlds/animal_well/names.py
@@ -261,6 +261,11 @@ class ItemNames(str, Enum):
     # rename tanking_damage's string when we have enough spots to make it viable as an option or something
     tanking_damage = "Tanking Damage"  # for spots you can get to by taking up to 3 hearts of damage
     weird_tricks = "Weird Tricks"  # skips that are questionably in logic and may constitute a difficulty setting later
+    ball_throwing = "Ball Throwing"  # logic for throwing the ball at anything other than a block or a spike
+    obscure_tricks = "Obscure Tricks"  # solutions that are weird but not necessarily difficult
+    precise_tricks = "Precise Tricks"  # solutions that are difficult but not necessarily weird
+    water_bounce = "Water Bounce"  # tricks that use Yoyo, B.Ball, or some other way to generate a splash effect to bounce off the water
+
 
     # songs, to potentially be randomized
     song_home = "Top of the Well Song"

--- a/worlds/animal_well/names.py
+++ b/worlds/animal_well/names.py
@@ -262,7 +262,7 @@ class ItemNames(str, Enum):
     tanking_damage = "Tanking Damage"  # for spots you can get to by taking up to 3 hearts of damage
     weird_tricks = "Weird Tricks"  # skips that are questionably in logic and may constitute a difficulty setting later
     ball_trick_easy = "Ball Throwing - Easy"  # logic for throwing the ball at anything other than a block or a spike
-    ball_trick_medium = "Ball Throwing - Medium"
+    ball_trick_medium = "Ball Throwing - Medium"  # at the moment, does NOT imply the existence of ball. Ball needs to be written separately in logic.
     ball_trick_hard = "Ball Throwing - Hard"
     obscure_tricks = "Obscure Tricks"  # solutions that are weird but not necessarily difficult
     precise_tricks = "Precise Tricks"  # solutions that are difficult but not necessarily weird

--- a/worlds/animal_well/names.py
+++ b/worlds/animal_well/names.py
@@ -261,7 +261,9 @@ class ItemNames(str, Enum):
     # rename tanking_damage's string when we have enough spots to make it viable as an option or something
     tanking_damage = "Tanking Damage"  # for spots you can get to by taking up to 3 hearts of damage
     weird_tricks = "Weird Tricks"  # skips that are questionably in logic and may constitute a difficulty setting later
-    ball_throwing = "Ball Throwing"  # logic for throwing the ball at anything other than a block or a spike
+    ball_trick_easy = "Ball Throwing - Easy"  # logic for throwing the ball at anything other than a block or a spike
+    ball_trick_medium = "Ball Throwing - Medium"
+    ball_trick_hard = "Ball Throwing - Hard"
     obscure_tricks = "Obscure Tricks"  # solutions that are weird but not necessarily difficult
     precise_tricks = "Precise Tricks"  # solutions that are difficult but not necessarily weird
     water_bounce = "Water Bounce"  # tricks that use Yoyo, B.Ball, or some other way to generate a splash effect to bounce off the water

--- a/worlds/animal_well/names.py
+++ b/worlds/animal_well/names.py
@@ -260,7 +260,6 @@ class ItemNames(str, Enum):
     can_defeat_ghost = "Can Defeat Ghost"
     # rename tanking_damage's string when we have enough spots to make it viable as an option or something
     tanking_damage = "Tanking Damage"  # for spots you can get to by taking up to 3 hearts of damage
-    weird_tricks = "Weird Tricks"  # skips that are questionably in logic and may constitute a difficulty setting later
     ball_trick_easy = "Ball Throwing - Easy"  # logic for throwing the ball at anything other than a block or a spike
     ball_trick_medium = "Ball Throwing - Medium"  # at the moment, does NOT imply the existence of ball. Ball needs to be written separately in logic.
     ball_trick_hard = "Ball Throwing - Hard"

--- a/worlds/animal_well/options.py
+++ b/worlds/animal_well/options.py
@@ -222,7 +222,7 @@ class AnimalWellOptions(PerGameCommonOptions):
     obscure_tricks: ObscureTricks
     precise_tricks: PreciseTricks
     tanking_damage: TankingDamage
-    wheel_tricks: WeirdTricks
+    weird_tricks: WeirdTricks
 
 
 aw_option_groups = [

--- a/worlds/animal_well/options.py
+++ b/worlds/animal_well/options.py
@@ -131,6 +131,47 @@ class WheelTricks(Choice):
     option_advanced = 2
     default = 0
 
+class BallThrowing(Choice):
+    """
+    Include in logic using the ball to hit switches or buttons not ""designed"" for it.
+    Off means the ball will rarely be used for anything other than breaking blocks, spikes or guard shields.
+    Simple means the ball can be used to hit easy targets without any real rebound, setup or moving. Most ""yoyo chute"" buttons are included here.
+    Advanced means hitting your target may require bouncing off a wall, or moving while throwing to adjust momentum or get a good angle.
+    Expert includes any more complicated tricks, including those that require specific setups or getting lucky.
+    """									
+    internal_name = "ball_throwing"
+    display_name = "Ball Throwing"
+    option_off = 0
+    option_simple = 1
+    option_advanced = 2
+    option_expert = 3
+    default = 0
+
+class ObscureTricks(Toggle):
+    """
+    Include a number of solutions to puzzles that are obscure or hard to understand.
+    These tricks aren't necessarily difficult to perform once you know what they are. If they are difficult, you must also turn on the respective difficulty or trick setting to enable it.
+    """
+    internal_name = "obscure_tricks"
+    display_name = "Obscure Tricks"
+
+class PreciseTricks(Toggle):
+    """
+    Include a number of solutions to puzzles that are mechanically difficult to execute.
+    These tricks may require large amounts of attempts to get right, and there may be a higher than usual cost for failure.
+    Tricks which are already covered by other item-specific trick options are not included here.
+    """
+    internal_name = "precise_tricks"
+    display_name = "Precise Tricks"
+
+class TankingDamage(Toggle):
+    """
+    Include tricks which require you to voluntarily take damage in order to perform them.
+    You may be expected to take up to three points of damage from any source. "Overtanking" with blue hearts will never be in logic.
+    """
+    internal_name = "tanking_damage"
+    display_name = "Tanking Damage"
+
 class ExcludeSongChests(DefaultOnToggle):
     """
     Exclude the Wheel chest and Office Key chests, so that you don't have to play their songs.
@@ -168,8 +209,11 @@ class AnimalWellOptions(PerGameCommonOptions):
     disc_hopping: DiscHopping
     wheel_tricks: WheelTricks
     exclude_song_chests: ExcludeSongChests
-
+    ball_throwing: BallThrowing
     wheel_hopping: WheelHopping
+    obscure_tricks: ObscureTricks
+    precise_tricks: PreciseTricks
+    tanking_damage: TankingDamage
 
 
 aw_option_groups = [
@@ -177,6 +221,10 @@ aw_option_groups = [
         BubbleJumping,
         DiscHopping,
         WheelTricks,
+        BallThrowing,
+        ObscureTricks,
+        PreciseTricks,
+        TankingDamage
     ])
 ]
 
@@ -186,6 +234,10 @@ aw_option_presets: Dict[str, Dict[str, Any]] = {
         "bubble_jumping": BubbleJumping.option_on,
         "disc_hopping": DiscHopping.option_multiple,
         "wheel_tricks": WheelTricks.option_advanced,
-        "bunnies_as_checks": BunniesAsChecks.option_all_bunnies
+        "bunnies_as_checks": BunniesAsChecks.option_all_bunnies,
+        "ball_throwing": BallThrowing.option_expert,
+        "obscure_tricks": ObscureTricks.option_true,
+        "precise_tricks": PreciseTricks.option_true,
+        "tanking_damage": TankingDamage.option_true,
     },
 }

--- a/worlds/animal_well/options.py
+++ b/worlds/animal_well/options.py
@@ -193,6 +193,14 @@ class WheelHopping(Choice):
     default = 0
     visibility = Visibility.none
 
+class WeirdTricks(Toggle):
+    """
+    Included temporarily for backward compatibility.
+    Logically equivalent to ball_throwing: expert, tanking_damage: true, precise_tricks: true, obscure_tricks: true
+    """
+    internal_name = "weird_tricks"
+    display_name = "Weird Tricks"
+    visibility = Visibility.none
 
 @dataclass
 class AnimalWellOptions(PerGameCommonOptions):
@@ -214,6 +222,7 @@ class AnimalWellOptions(PerGameCommonOptions):
     obscure_tricks: ObscureTricks
     precise_tricks: PreciseTricks
     tanking_damage: TankingDamage
+    wheel_tricks: WeirdTricks
 
 
 aw_option_groups = [
@@ -224,7 +233,8 @@ aw_option_groups = [
         BallThrowing,
         ObscureTricks,
         PreciseTricks,
-        TankingDamage
+        TankingDamage,
+        WeirdTricks,
     ])
 ]
 
@@ -239,5 +249,6 @@ aw_option_presets: Dict[str, Dict[str, Any]] = {
         "obscure_tricks": ObscureTricks.option_true,
         "precise_tricks": PreciseTricks.option_true,
         "tanking_damage": TankingDamage.option_true,
+        "weird_tricks": WeirdTricks.option_true,
     },
 }

--- a/worlds/animal_well/options.py
+++ b/worlds/animal_well/options.py
@@ -131,17 +131,6 @@ class WheelTricks(Choice):
     option_advanced = 2
     default = 0
 
-
-class WeirdTricks(Toggle):
-    """
-    Include performing "weird" tricks in the logic.
-    Some of these tricks are difficult, tedious, or inconsistent.
-    Use at your own risk.
-    """
-    internal_name = "weird_tricks"
-    display_name = "Weird Tricks"
-
-
 class ExcludeSongChests(DefaultOnToggle):
     """
     Exclude the Wheel chest and Office Key chests, so that you don't have to play their songs.
@@ -178,7 +167,6 @@ class AnimalWellOptions(PerGameCommonOptions):
     bubble_jumping: BubbleJumping
     disc_hopping: DiscHopping
     wheel_tricks: WheelTricks
-    weird_tricks: WeirdTricks
     exclude_song_chests: ExcludeSongChests
 
     wheel_hopping: WheelHopping
@@ -189,7 +177,6 @@ aw_option_groups = [
         BubbleJumping,
         DiscHopping,
         WheelTricks,
-        WeirdTricks,
     ])
 ]
 
@@ -199,7 +186,6 @@ aw_option_presets: Dict[str, Dict[str, Any]] = {
         "bubble_jumping": BubbleJumping.option_on,
         "disc_hopping": DiscHopping.option_multiple,
         "wheel_tricks": WheelTricks.option_advanced,
-        "weird_tricks": True,
         "bunnies_as_checks": BunniesAsChecks.option_all_bunnies
     },
 }

--- a/worlds/animal_well/region_data.py
+++ b/worlds/animal_well/region_data.py
@@ -188,8 +188,7 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         rname.fish_tube_room:  # enter at the save room fish pipe, the rooms with all the fish pipes
             AWData(AWType.region, [[iname.bubble]]),
         lname.egg_sunset:  # break the spikes in the room to the right of the fish warp
-            AWData(AWType.location, [[iname.ball], [iname.yoyo], [iname.top], [iname.wheel, iname.disc],
-                                     [iname.disc, iname.weird_tricks],  # throw the disc while falling
+            AWData(AWType.location, [[iname.ball], [iname.yoyo], [iname.top], [iname.disc],
                                      [iname.wheel, iname.obscure_tricks]]),  # wheel while moving into the gap
         rname.water_spike_bunny_spot:
             AWData(AWType.region, [[iname.bubble_long]]),
@@ -204,7 +203,7 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
     },
     rname.fish_west: {
         rname.fish_wand_pit: 
-            AWData(AWType.region, [[iname.bubble], [iname.disc], [iname.wheel, iname.weird_tricks]]),
+            AWData(AWType.region, [[iname.bubble], [iname.disc], [iname.wheel]]),
         lname.egg_ancient:  # one room up and left of save point, vines in top right
         # single bubble possible, but it's much tighter than doing bubble_short, so it's not logical
             AWData(AWType.location, [[iname.bubble_short], [iname.disc_hop_hard], 
@@ -805,13 +804,13 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
             AWData(AWType.location),
         rname.frog_bird_after_yoyo_1:  # can bypass the locked door with bubble jumps + lantern
             AWData(AWType.region, [[iname.yoyo], [iname.bubble_long, iname.lantern], [iname.ball, iname.ball_trick_hard],
-                                   [iname.bubble_long, iname.weird_tricks]]),  # spam bubbles then jump up the left side
+                                   [iname.bubble_long_real, iname.precise_tricks]]),  # spam bubbles then jump up the left side
     },
     rname.frog_bird_after_yoyo_1: {
         rname.frog_bird_after_yoyo_2:  # pain in the ass, but you can get up with downwards bubbles
             AWData(AWType.region, [[iname.yoyo], [iname.bubble_long], [iname.ball, iname.ball_trick_medium]]),
         rname.frog_worm_shaft_bottom:  # if you fall along the left side, the bird doesn't reach you in time
-            AWData(AWType.region, [[iname.weird_tricks], [iname.lantern]]),
+            AWData(AWType.region, [[iname.obscure_tricks], [iname.lantern]]),
         lname.egg_sapphire:
             AWData(AWType.location, [[iname.lantern]]),
     },

--- a/worlds/animal_well/region_data.py
+++ b/worlds/animal_well/region_data.py
@@ -759,7 +759,7 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         lname.egg_travel:
             AWData(AWType.location),
         rname.frog_ostrich_attack:
-            AWData(AWType.region, [[iname.yoyo], [iname.ball]]),
+            AWData(AWType.region, [[iname.yoyo], [iname.ball, iname.ball_trick_easy]]),
         rname.frog_near_wombat:
             AWData(AWType.region, [[iname.key_ring]]),  # assuming the key can open it from the left
     },
@@ -797,12 +797,12 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         lname.yoyo_chest:
             AWData(AWType.location),
         rname.frog_bird_after_yoyo_1:  # can bypass the locked door with bubble jumps + lantern
-            AWData(AWType.region, [[iname.yoyo], [iname.bubble_long, iname.lantern], [iname.ball, iname.weird_tricks],
+            AWData(AWType.region, [[iname.yoyo], [iname.bubble_long, iname.lantern], [iname.ball, iname.ball_trick_hard],
                                    [iname.bubble_long, iname.weird_tricks]]),  # spam bubbles then jump up the left side
     },
     rname.frog_bird_after_yoyo_1: {
         rname.frog_bird_after_yoyo_2:  # pain in the ass, but you can get up with downwards bubbles
-            AWData(AWType.region, [[iname.yoyo], [iname.bubble_long], [iname.ball, iname.weird_tricks]]),
+            AWData(AWType.region, [[iname.yoyo], [iname.bubble_long], [iname.ball, iname.ball_trick_medium]]),
         rname.frog_worm_shaft_bottom:  # if you fall along the left side, the bird doesn't reach you in time
             AWData(AWType.region, [[iname.weird_tricks], [iname.lantern]]),
         lname.egg_sapphire:
@@ -819,7 +819,7 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         # 2 doors in the top right of this region
         lname.key_frog_guard_room_east:
             AWData(AWType.location, [[iname.yoyo], [iname.bubble, iname.flute], 
-                                     [iname.ball], [iname.flute, iname.weird_tricks]]),
+                                     [iname.ball], [iname.flute, iname.obscure_tricks]]),
         rname.frog_dark_room:  # yoyo to open the door, lantern to fall through the bird
             AWData(AWType.region, [[iname.yoyo], [iname.lantern], [iname.ball]]),
         rname.frog_ruby_egg_ledge:  # fall through a bird onto it
@@ -860,9 +860,9 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
             AWData(AWType.location),  # you need yoyo and bubble to get to this check logically
             # if you have yoyo, you can swap the mouse direction and lock yourself out of the check without bubbles
         lname.egg_obsidian:  # bounce disc between the moving walls, or do some cursed bubble jumps
-            AWData(AWType.location, [[iname.disc], [iname.bubble_short, iname.weird_tricks]]),
+            AWData(AWType.location, [[iname.disc], [iname.bubble_short, iname.precise_tricks]]),
         lname.egg_golden:  # simultaneous buttons. Need an item to hold it down. I don't think top is unintuitive enough to warrant weird, but disc definitely is.
-            AWData(AWType.location, [[iname.wheel, iname.slink], [iname.wheel, iname.top], [iname.wheel, iname.disc, iname.weird_tricks]]),
+            AWData(AWType.location, [[iname.wheel, iname.slink], [iname.wheel, iname.top], [iname.wheel, iname.disc, iname.obscure_tricks]]),
         lname.flame_green:
             AWData(AWType.location, [[iname.can_open_flame]], event=iname.green_flame),
         rname.bobcat_room:
@@ -884,19 +884,21 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
             AWData(AWType.location, [[iname.flute]], event=iname.activated_hippo_fast_travel),
         lname.lantern_chest:
             AWData(AWType.location, [[iname.slink, iname.disc, iname.yoyo], [iname.lantern],
-                                     [iname.ball, iname.slink, iname.weird_tricks]]),
+                                     [iname.ball, iname.slink, iname.ball_trick_hard]]),
         rname.hippo_manticore_room:
             AWData(AWType.region, [[iname.lantern, iname.yoyo, iname.disc], 
                                    [iname.lantern, iname.yoyo, iname.wheel_hop, iname.tanking_damage],
                                    # running into the miasma with yoyo out can hit the rightmost button
                                    [iname.lantern, iname.yoyo, iname.bubble, iname.tanking_damage],
-                                   [iname.lantern, iname.ball, iname.wheel_hop, iname.weird_tricks], 
-                                   [iname.lantern, iname.ball, iname.bubble, iname.weird_tricks],
                                    # all buttons can be hit with ball with enough patience
-                                   [iname.lantern, iname.ball, iname.disc, iname.weird_tricks],
-                                   [iname.lantern, iname.ball, iname.wheel_hop, iname.yoyo],
-                                   # weird tricks for the yoyo loop button. ball can hit rightmost button easy
-                                   [iname.lantern, iname.ball, iname.bubble, iname.yoyo]]),
+                                   [iname.lantern, iname.ball, iname.wheel_hop, iname.ball_trick_medium], 
+                                   [iname.lantern, iname.ball, iname.bubble, iname.ball_trick_medium],
+                                   [iname.lantern, iname.ball, iname.disc, iname.ball_trick_medium],
+                                   [iname.lantern, iname.ball, iname.water_bounce, iname.ball_trick_medium],
+                                   # easy ball trick if you have yoyo to hit yoyo chute button, medium otherwise
+                                   [iname.lantern, iname.ball, iname.wheel_hop, iname.yoyo, iname.ball_trick_easy],
+                                   [iname.lantern, iname.ball, iname.water_bounce, iname.yoyo, iname.ball_trick_easy],
+                                   [iname.lantern, iname.ball, iname.bubble, iname.yoyo, iname.ball_trick_easy]]),
     },
     rname.hippo_manticore_room: {
         rname.hippo_fireworks:  # todo: verify you need disc
@@ -947,7 +949,7 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         rname.bear_match_chest_spot:
             AWData(AWType.region, [[iname.wheel_hard], [iname.bubble]]),
         rname.bear_truth_egg_spot:
-            AWData(AWType.region, [[iname.wheel_hard], [iname.bubble, iname.weird_tricks]]),
+            AWData(AWType.region, [[iname.wheel_hard], [iname.bubble, iname.precise_tricks]]),
     },
     rname.chocolate_egg_spot: {
         lname.egg_chocolate:  # across from center well match
@@ -959,7 +961,7 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         rname.top_of_the_well:
             AWData(AWType.region, [[iname.bubble_long], [iname.wheel_hard]]),
         rname.bear_truth_egg_spot:
-            AWData(AWType.region, [[iname.wheel_hard], [iname.bubble, iname.weird_tricks]]),
+            AWData(AWType.region, [[iname.wheel_hard], [iname.bubble, iname.precise_tricks]]),
     },
     rname.match_center_well_spot: {
         lname.match_center_well:  # across from the chocolate egg
@@ -971,7 +973,7 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         rname.top_of_the_well:
             AWData(AWType.region, [[iname.bubble_long], [iname.wheel_hard]]),
         rname.bear_truth_egg_spot:
-            AWData(AWType.region, [[iname.wheel_hard], [iname.bubble, iname.weird_tricks]]),
+            AWData(AWType.region, [[iname.wheel_hard], [iname.bubble, iname.precise_tricks]]),
     },
 
     rname.fast_travel: {

--- a/worlds/animal_well/region_data.py
+++ b/worlds/animal_well/region_data.py
@@ -228,7 +228,7 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
     rname.fish_lower: {
         rname.fish_west:
             AWData(AWType.region, [[iname.bubble]]),  # fish pipe left of the save point
-        rname.fish_boss_1:  # weird_trick: reflect water while standing on ladder to skip disc req. Other requirements are for passing whale room w/o disc
+        rname.fish_boss_1:  # reflect water while standing on ladder to skip disc req. Other requirements are for passing whale room w/o disc
             AWData(AWType.region, [[iname.disc], [iname.obscure_tricks, iname.bubble_long], 
                                    [iname.obscure_tricks, iname.wheel_hop, iname.ball, iname.ball_trick_medium], 
                                    [iname.obscure_tricks, iname.bubble, iname.ball, iname.ball_trick_medium]]),
@@ -752,7 +752,7 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
             # bubble short or maybe just bubble? You have to shoot down at the apex of your jump, feels weird
             # I was getting this 90% of the time, not sure it's intuitive? make it logical and put it in the tricks FAQ.
         lname.egg_promise:  # under spikes in 3 bird room, solve puzzle then can break spikes without bird in the way
-            # weird tricks: fall onto spikes while throwing disc to the left with good timing to break a path
+            # fall onto spikes while throwing disc to the left with good timing to break a path
             AWData(AWType.location, [[iname.can_break_spikes_below], [iname.disc, iname.tanking_damage]]),
         rname.frog_under_ostrich_statue:  # after hitting the switch, no items needed
             AWData(AWType.region),
@@ -867,7 +867,7 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
             # if you have yoyo, you can swap the mouse direction and lock yourself out of the check without bubbles
         lname.egg_obsidian:  # bounce disc between the moving walls, or do some cursed bubble jumps
             AWData(AWType.location, [[iname.disc], [iname.bubble_short, iname.precise_tricks]]),
-        lname.egg_golden:  # simultaneous buttons. Need an item to hold it down. I don't think top is unintuitive enough to warrant weird, but disc definitely is.
+        lname.egg_golden:  # simultaneous buttons. Need an item to hold it down. I don't think top is unintuitive enough to warrant obscure, but disc definitely is.
             AWData(AWType.location, [[iname.wheel, iname.slink], [iname.wheel, iname.top], [iname.wheel, iname.disc, iname.obscure_tricks]]),
         lname.flame_green:
             AWData(AWType.location, [[iname.can_open_flame]], event=iname.green_flame),

--- a/worlds/animal_well/region_data.py
+++ b/worlds/animal_well/region_data.py
@@ -896,12 +896,13 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
                                    [iname.lantern, iname.yoyo, iname.wheel_hop, iname.tanking_damage],
                                    # running into the miasma with yoyo out can hit the rightmost button
                                    [iname.lantern, iname.yoyo, iname.bubble, iname.tanking_damage],
+                                   [iname.lantern, iname.yoyo, iname.water_bounce, iname.tanking_damage],
                                    # all buttons can be hit with ball with enough patience
-                                   [iname.lantern, iname.ball, iname.wheel_hop, iname.ball_trick_medium], 
-                                   [iname.lantern, iname.ball, iname.bubble, iname.ball_trick_medium],
-                                   [iname.lantern, iname.ball, iname.disc, iname.ball_trick_medium],
-                                   [iname.lantern, iname.ball, iname.water_bounce, iname.ball_trick_medium],
-                                   # easy ball trick if you have yoyo to hit yoyo chute button, medium otherwise
+                                   [iname.lantern, iname.ball, iname.wheel_hop, iname.ball_trick_hard], 
+                                   [iname.lantern, iname.ball, iname.bubble, iname.ball_trick_hard],
+                                   [iname.lantern, iname.ball, iname.disc, iname.ball_trick_hard],
+                                   [iname.lantern, iname.ball, iname.water_bounce, iname.ball_trick_hard],
+                                   # easy ball trick if you have yoyo to hit yoyo chute button, hard otherwise
                                    [iname.lantern, iname.ball, iname.wheel_hop, iname.yoyo, iname.ball_trick_easy],
                                    [iname.lantern, iname.ball, iname.water_bounce, iname.yoyo, iname.ball_trick_easy],
                                    [iname.lantern, iname.ball, iname.bubble, iname.yoyo, iname.ball_trick_easy]]),

--- a/worlds/animal_well/region_data.py
+++ b/worlds/animal_well/region_data.py
@@ -180,11 +180,11 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         lname.egg_mystic:  # avoid the fireball thrower, hit some buttons
             AWData(AWType.location),
         lname.egg_great:  # east end of the crane room
-            AWData(AWType.location, [[iname.bubble], [iname.disc_hop], [iname.wheel_hop]]),
+            AWData(AWType.location, [[iname.bubble], [iname.disc_hop], [iname.wheel_hop], [iname.water_bounce, iname.yoyo], [iname.water_bounce, iname.ball]]),
         lname.egg_normal:  # hidden wall in lower left of first bubble room
             AWData(AWType.location),
         lname.egg_dazzle:  # little obstacle course, feels like the bubble jump tutorial?
-            AWData(AWType.location, [[iname.bubble], [iname.disc, iname.wheel], [iname.disc_hop_hard]]),
+            AWData(AWType.location, [[iname.bubble], [iname.disc, iname.wheel], [iname.disc_hop_hard], [iname.wheel_hard]]),
         rname.fish_tube_room:  # enter at the save room fish pipe, the rooms with all the fish pipes
             AWData(AWType.region, [[iname.bubble]]),
         lname.egg_sunset:  # break the spikes in the room to the right of the fish warp
@@ -209,8 +209,8 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
             AWData(AWType.location, [[iname.bubble_short], [iname.disc_hop_hard], 
                                      [iname.wheel_hard], [iname.bubble, iname.disc]]),
         rname.fish_lower:  # bubble to go down, activate switches, breakspike to pass icicles in first penguin room
-            AWData(AWType.region, [[iname.bubble, iname.remote, iname.can_break_spikes],
-                                   [iname.remote, iname.wheel_hard], [iname.disc, iname.wheel_hard, iname.precise_tricks],  # throwing disc to hit switch while wheel stalling is very tight
+            AWData(AWType.region, [[iname.bubble, iname.remote, iname.can_break_spikes], [iname.bubble, iname.remote, iname.tanking_damage]
+                                   [iname.remote, iname.wheel_hop], [iname.disc, iname.wheel_hop, iname.precise_tricks],  # throwing disc to hit switch while wheel stalling is very tight
                                    [iname.bubble, iname.disc]]),
         lname.activate_fish_fast_travel:  # vertical implied by access
             AWData(AWType.location, [[iname.flute]], event=iname.activated_fish_fast_travel),
@@ -381,7 +381,7 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         rname.bear_ladder_after_chameleon:
             AWData(AWType.region),  # just press a button
         rname.bear_middle_phone_room:
-            AWData(AWType.region, [[iname.slink]]),
+            AWData(AWType.region, [[iname.slink], [iname.ball_trick_easy]]),
         lname.egg_post_modern:
             AWData(AWType.location, [[iname.top, iname.switch_for_post_modern_egg]]),
         rname.bear_truth_egg_spot:  # throw disc to the right after jumping down the waterfall
@@ -633,7 +633,7 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         rname.bear_middle_phone_room:
             AWData(AWType.region),  # activate dynamite
         lname.egg_plant:
-            AWData(AWType.location, [[iname.disc, iname.slink]]),
+            AWData(AWType.location, [[iname.disc, iname.slink], [iname.bubble_short, iname.obscure_tricks]]),
         rname.kangaroo_blocks:
             AWData(AWType.region, [[iname.ball]]),
     },
@@ -836,8 +836,8 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
             AWData(AWType.region, [[iname.key_ring]]),
     },
     rname.frog_dark_room: {
-        rname.frog_bird_after_yoyo_2:  # jump up at the rust egg with lantern, or use yoyo to open the door
-            AWData(AWType.region, [[iname.lantern], [iname.yoyo]]),
+        rname.frog_bird_after_yoyo_2:  # jump up at the rust egg with lantern, or use yoyo to open the door, or cheek past the bird with well timed bubble jumps
+            AWData(AWType.region, [[iname.lantern], [iname.yoyo], [iname.bubble_short, iname.precise_tricks]]),
         lname.egg_rust:  # top left of the dark room
             AWData(AWType.location),
         lname.egg_jade:  # do the puzzle
@@ -845,7 +845,7 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         rname.bird_capybara_waterfall:  # fish pipe to the sweet egg room
             AWData(AWType.region, [[iname.bubble]]),
         rname.frog_ruby_egg_ledge:
-            AWData(AWType.region, [[iname.bubble_short], [iname.disc], [iname.top, iname.flute]]),
+            AWData(AWType.region, [[iname.bubble_short], [iname.disc], [iname.top, iname.flute], [iname.top, iname.firecrackers]]),
         rname.frog_elevator_and_ostrich_wheel:  # you need these two items to avoid locking checks
             AWData(AWType.region, [[iname.yoyo, iname.bubble]]),
         rname.fast_travel:
@@ -866,7 +866,7 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
             AWData(AWType.location),  # you need yoyo and bubble to get to this check logically
             # if you have yoyo, you can swap the mouse direction and lock yourself out of the check without bubbles
         lname.egg_obsidian:  # bounce disc between the moving walls, or do some cursed bubble jumps
-            AWData(AWType.location, [[iname.disc], [iname.bubble_short, iname.precise_tricks]]),
+            AWData(AWType.location, [[iname.disc], [iname.bubble_short, iname.precise_tricks], [iname.water_bounce, iname.yoyo], [iname.water_bounce, iname.ball]]),
         lname.egg_golden:  # simultaneous buttons. Need an item to hold it down. I don't think top is unintuitive enough to warrant obscure, but disc definitely is.
             AWData(AWType.location, [[iname.wheel, iname.slink], [iname.wheel, iname.top], [iname.wheel, iname.disc, iname.obscure_tricks]]),
         lname.flame_green:

--- a/worlds/animal_well/region_data.py
+++ b/worlds/animal_well/region_data.py
@@ -309,8 +309,8 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         rname.zen_egg_spot:
             AWData(AWType.region, [[iname.bubble], [iname.disc], [iname.wheel_hop]]),
         rname.bear_dark_maze:  # need one key to open the gate, or do downward bubbles to get to the button
-            AWData(AWType.region, [[iname.key_ring], [iname.bubble_short, iname.weird_tricks],
-                                   [iname.ball, iname.weird_tricks]]),  # or hit it with a ball
+            AWData(AWType.region, [[iname.key_ring], [iname.bubble_short, iname.precise_tricks],
+                                   [iname.ball, iname.ball_trick_medium]]),  # or hit it with a ball
         rname.value_egg_spot:
             AWData(AWType.region, [[iname.bubble_short], [iname.disc], [iname.wheel_climb]]),
     },
@@ -325,7 +325,7 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
     rname.value_egg_spot: {  # broke this one out into its own region because the reqs were getting really big
         lname.egg_value:
             AWData(AWType.location, [[iname.firecrackers], [iname.disc_hop_hard], 
-                                     [iname.flute], [iname.ball, iname.weird_tricks]]),
+                                     [iname.flute], [iname.ball, iname.ball_trick_medium]]),
     },
     rname.bear_future_egg_room: {
         lname.egg_future:  # chinchilla on the moving platforms puzzle room
@@ -368,7 +368,7 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         rname.bear_transcendental:  # descend, jump into left wall, or disc hop from the platforms underneath
             AWData(AWType.region, [[iname.slink, iname.bubble], [iname.top, iname.bubble],
                                    [iname.slink, iname.disc_hop], [iname.top, iname.disc_hop],
-                                   [iname.ball, iname.disc_hop], [iname.ball, iname.bubble]]),
+                                   [iname.ball, iname.disc_hop, iname.ball_trick_easy], [iname.ball, iname.bubble, iname.ball_trick_easy]]),
         # bear_area_entry:  # unnecessary because it's a sphere 1 area
         #     AWData(AWType.region),
     },
@@ -402,10 +402,10 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         lname.egg_chaos:  # in the room with the monkey that throws rocks at you
             AWData(AWType.location),
         rname.bear_crow_rooms:
-            AWData(AWType.region, [[iname.slink], [iname.ball, iname.weird_tricks]]),
+            AWData(AWType.region, [[iname.slink], [iname.ball, iname.ball_trick_hard]]),
         rname.bear_match_chest_spot:  # shoots some hoops! throw the ball to the button. can be done without vertical if you throw early
-            AWData(AWType.region, [[iname.ball, iname.weird_tricks], [iname.bubble, iname.tanking_damage],
-                                   [iname.disc, iname.tanking_damage, iname.weird_tricks]]),
+            AWData(AWType.region, [[iname.ball, iname.ball_trick_medium], [iname.bubble, iname.tanking_damage],
+                                   [iname.disc, iname.tanking_damage, iname.precise_tricks]]),
         rname.bear_chameleon_room_2:
             AWData(AWType.region, [[iname.bubble_long, iname.tanking_damage], [iname.disc_hop_hard, iname.tanking_damage]]),
     },
@@ -415,7 +415,7 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         lname.bunny_crow:  # it jumps down after a moment
             AWData(AWType.location, [[iname.flute]], loc_type=LocType.bunny),
         rname.bear_hedgehog_square:  # slink needed for puzzle to get to the button
-            AWData(AWType.region, [[iname.slink], [iname.ball, iname.weird_tricks]]),
+            AWData(AWType.region, [[iname.slink], [iname.ball, iname.ball_trick_hard]]),
     },
     rname.bear_shadow_egg_spot: {
         lname.egg_shadow:
@@ -448,18 +448,18 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
             AWData(AWType.region),  # wall is flush, just hold left
         rname.bear_truth_egg_spot:
             # fall down the shaft, catch yourself on a bubble, and jump right quickly before the bird pops it
-            AWData(AWType.region, [[iname.wheel_hard], [iname.bubble, iname.weird_tricks]]),
+            AWData(AWType.region, [[iname.wheel_hard], [iname.bubble, iname.precise_tricks]]),
         # top_of_the_well:  # unnecessary because of the connection from match center spot
         #     AWData(AWType.region, [[iname.bubble_long]]),
         rname.bear_upper_phone_room:
             AWData(AWType.region, [[iname.slink, iname.yoyo],
-                                   [iname.slink, iname.ball, iname.weird_tricks],
+                                   [iname.slink, iname.ball, iname.ball_trick_easy],
                                    # throw the ball in the yoyo pipe then run left with yoyo or slink
-                                   [iname.yoyo, iname.ball, iname.weird_tricks]]),
+                                   [iname.yoyo, iname.ball, iname.ball_trick_easy]]),
     },
     rname.bear_upper_phone_room: {
         rname.bear_above_chameleon:
-            AWData(AWType.region, [[iname.yoyo], [iname.ball, iname.weird_tricks]]),
+            AWData(AWType.region, [[iname.yoyo], [iname.ball, iname.ball_trick_medium, iname.obscure_tricks]]),
     },
     rname.bear_above_chameleon: {  # includes the screens to the right of it
         lname.egg_swan:  # wake one chinchilla, lure upper one right, run left
@@ -474,8 +474,13 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         rname.bear_chameleon_room_2:
             AWData(AWType.region, [[iname.yoyo, iname.slink, iname.flute],
                                    [iname.yoyo, iname.slink, iname.firecrackers],
-                                   [iname.ball, iname.flute, iname.weird_tricks],
-                                   [iname.ball, iname.firecrackers, iname.weird_tricks]]),
+                                   # hitting lower button with ball is medium, hitting upper through 1way is hard.
+                                   [iname.ball, iname.flute, iname.ball_trick_medium],
+                                   [iname.ball, iname.firecrackers, iname.ball_trick_medium],
+                                   [iname.ball, iname.bubble, iname. ball_trick_hard],
+                                   [iname.ball, iname.disc, iname.ball_trick_hard],
+                                   [iname.ball, iname.wheel_hop, iname.ball_trick_hard],
+                                   ]),
     },
     rname.bear_chameleon_room_2: {
         rname.bear_middle_phone_room:  # drop down, probably unimportant
@@ -508,8 +513,8 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         lname.candle_dog_dark_event:
             AWData(AWType.location, [[iname.matchbox]], event=iname.event_candle_dog_dark),
         rname.dog_chinchilla_skull:  # hit a switch with any number of things, or jump up there yourself
-            AWData(AWType.region, [[iname.bubble], [iname.remote], [iname.disc], [iname.ball], [iname.wheel_hop],
-                                   [iname.top, iname.weird_tricks]]),
+            AWData(AWType.region, [[iname.bubble], [iname.remote], [iname.disc], [iname.ball, iname.ball_trick_easy], [iname.wheel_hop],
+                                   [iname.top, iname.obscure_tricks]]),
         rname.dog_upside_down_egg_spot:  # upper right of switch platform room above second dog
             AWData(AWType.region, [[iname.bubble_short]]),
         rname.dog_at_mock_disc:  # you drop down to here, but can't get back up immediately
@@ -563,7 +568,7 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         lname.bunny_lava:
             AWData(AWType.location, [[iname.bubble_long, iname.remote]], loc_type=LocType.bunny),
         rname.dog_many_switches:
-            AWData(AWType.region, [[iname.ball], [iname.yoyo], [iname.disc], [iname.wheel, iname.bubble],
+            AWData(AWType.region, [[iname.ball, iname.ball_trick_medium], [iname.yoyo], [iname.disc], [iname.wheel, iname.bubble],
                                    [iname.wheel_hop], [iname.top]]),
         rname.dog_under_fast_travel_room:  # very tight, need to jump from the lower ledge one room to the right
             AWData(AWType.region, [[iname.switch_next_to_bat_room], [iname.bubble_short], [iname.disc_hop], [iname.wheel_climb]]),
@@ -580,13 +585,13 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         lname.activate_dog_fast_travel:
             AWData(AWType.location, [[iname.flute]], event=iname.activated_dog_fast_travel),
         rname.dog_swordfish_lake_ledge:
-            AWData(AWType.region, [[iname.disc], [iname.bubble_long_real], [iname.bubble_long, iname.weird_tricks]]),
+            AWData(AWType.region, [[iname.disc], [iname.bubble_long_real], [iname.bubble_long, iname.precise_tricks]]),
         rname.dog_upper_past_lake:  # ride bubble down, jump the partial-height wall
             AWData(AWType.region, [[iname.bubble]]),
         rname.dog_above_fast_travel:  # disc: go across lake, then go back at higher elevation. wheel_hop: jump off the moving block
             AWData(AWType.region, [[iname.slink], [iname.bubble_short], [iname.disc], [iname.wheel_hop]]),
         rname.dog_mock_disc_shrine:
-            AWData(AWType.region, [[iname.slink], [iname.wheel_hop], [iname.top, iname.weird_tricks]]),
+            AWData(AWType.region, [[iname.slink], [iname.wheel_hop], [iname.top, iname.precise_tricks]]),
     },
     rname.dog_mock_disc_shrine: {
         lname.egg_raw:
@@ -608,9 +613,9 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
             AWData(AWType.region),
         lname.egg_crystal:
             AWData(AWType.location, [[iname.top, iname.ball, iname.remote, iname.wheel, iname.slink],
-                                     [iname.top, iname.ball, iname.remote, iname.wheel, iname.disc, iname.weird_tricks],  # rooby's version
-                                     [iname.top, iname.wheel_hop, iname.weird_tricks],  # 8's version
-                                     [iname.top, iname.wheel, iname.bubble_long, iname.weird_tricks]]),  # 8's OTHER version
+                                     [iname.top, iname.ball, iname.remote, iname.wheel, iname.disc, iname.obscure_tricks],  # rooby's version
+                                     [iname.top, iname.wheel_hop, iname.obscure_tricks, iname.precise_tricks],  # 8's version
+                                     [iname.top, iname.wheel, iname.bubble_long, iname.obscure_tricks, iname.precise_tricks]]),  # 8's OTHER version
     },
     rname.dog_swordfish_lake_ledge: {
         rname.dog_fast_travel_room:
@@ -618,7 +623,7 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         lname.egg_forbidden:
             AWData(AWType.location),
         lname.bunny_disc_spike:  # not disc hop since you literally need to do this
-            AWData(AWType.location, [[iname.disc], [iname.bubble_long, iname.wheel_hop, iname.weird_tricks]],
+            AWData(AWType.location, [[iname.disc], [iname.bubble_long, iname.wheel_hop, iname.precise_tricks]],
                    loc_type=LocType.bunny),
         rname.behind_kangaroo:
             AWData(AWType.region, [[iname.slink]]),

--- a/worlds/animal_well/region_data.py
+++ b/worlds/animal_well/region_data.py
@@ -638,7 +638,7 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
             AWData(AWType.location, [[iname.matchbox]], event=iname.event_candle_dog_many_switches),
         rname.dog_upside_down_egg_spot:  # throw a disc or top at a switch
             AWData(AWType.region, [[iname.remote], [iname.disc], [iname.top], 
-                                   [iname.ball, iname.weird_tricks]]),
+                                   [iname.ball, iname.ball_trick_easy]]),
         rname.dog_bat_room:
             AWData(AWType.region),
     },
@@ -747,7 +747,7 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
             # I was getting this 90% of the time, not sure it's intuitive? make it logical and put it in the tricks FAQ.
         lname.egg_promise:  # under spikes in 3 bird room, solve puzzle then can break spikes without bird in the way
             # weird tricks: fall onto spikes while throwing disc to the left with good timing to break a path
-            AWData(AWType.location, [[iname.can_break_spikes_below], [iname.disc, iname.weird_tricks]]),
+            AWData(AWType.location, [[iname.can_break_spikes_below], [iname.disc, iname.tanking_damage]]),
         rname.frog_under_ostrich_statue:  # after hitting the switch, no items needed
             AWData(AWType.region),
         rname.frog_travel_egg_spot:

--- a/worlds/animal_well/region_data.py
+++ b/worlds/animal_well/region_data.py
@@ -51,7 +51,7 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         rname.hippo_entry:
             AWData(AWType.region, [[iname.blue_flame, iname.green_flame, iname.pink_flame, iname.violet_flame]]),
         rname.bear_truth_egg_spot:
-            AWData(AWType.region, [[iname.disc_hop_hard], [iname.bubble_long_real, iname.weird_tricks]]),
+            AWData(AWType.region, [[iname.disc_hop_hard], [iname.bubble_long_real, iname.obscure_tricks]]),
         lname.stamp_chest:
             AWData(AWType.location),
         rname.bird_flute_chest:
@@ -74,8 +74,8 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         lname.egg_virtual:  # sneaky passage in the top left of the screen with the penguin hedges
             AWData(AWType.location),
         rname.match_above_egg_room:
-            AWData(AWType.region, [[iname.disc], [iname.bubble_short], [iname.ball, iname.weird_tricks],
-                                   [iname.yoyo], [iname.top, iname.weird_tricks]]),
+            AWData(AWType.region, [[iname.disc], [iname.bubble_short], [iname.ball, iname.ball_trick_easy],
+                                   [iname.yoyo], [iname.top, iname.obscure_tricks]]),
         lname.egg_holiday:  # in the wall to the right of the egg room entrance
             AWData(AWType.location, [[iname.bubble], [iname.disc_hop], [iname.wheel_hard]]),
         lname.egg_rain:
@@ -112,7 +112,7 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
     rname.starting_area: {
         rname.starting_after_ghost:  # it would feel weird to call this the central area imo
             AWData(AWType.region, [[iname.firecrackers], [iname.lantern], [iname.event_candle_first],
-                                   [iname.weird_tricks]]),  # speedrunner trick
+                                   [iname.water_bounce]]),  # speedrunner trick
         rname.candle_area:
             AWData(AWType.region, [[iname.event_candle_first, iname.event_candle_dog_dark,
                                     iname.event_candle_dog_switch_box, iname.event_candle_dog_many_switches,
@@ -190,7 +190,7 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         lname.egg_sunset:  # break the spikes in the room to the right of the fish warp
             AWData(AWType.location, [[iname.ball], [iname.yoyo], [iname.top], [iname.wheel, iname.disc],
                                      [iname.disc, iname.weird_tricks],  # throw the disc while falling
-                                     [iname.wheel, iname.weird_tricks]]),  # wheel while moving into the gap
+                                     [iname.wheel, iname.obscure_tricks]]),  # wheel while moving into the gap
         rname.water_spike_bunny_spot:
             AWData(AWType.region, [[iname.bubble_long]]),
     },
@@ -211,7 +211,7 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
                                      [iname.wheel_hard], [iname.bubble, iname.disc]]),
         rname.fish_lower:  # bubble to go down, activate switches, breakspike to pass icicles in first penguin room
             AWData(AWType.region, [[iname.bubble, iname.remote, iname.can_break_spikes],
-                                   [iname.remote, iname.wheel_hard], [iname.disc, iname.wheel_hard, iname.weird_tricks],  # throwing disc to hit switch while wheel stalling is very tight
+                                   [iname.remote, iname.wheel_hard], [iname.disc, iname.wheel_hard, iname.precise_tricks],  # throwing disc to hit switch while wheel stalling is very tight
                                    [iname.bubble, iname.disc]]),
         lname.activate_fish_fast_travel:  # vertical implied by access
             AWData(AWType.location, [[iname.flute]], event=iname.activated_fish_fast_travel),
@@ -230,7 +230,9 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         rname.fish_west:
             AWData(AWType.region, [[iname.bubble]]),  # fish pipe left of the save point
         rname.fish_boss_1:  # weird_trick: reflect water while standing on ladder to skip disc req. Other requirements are for passing whale room w/o disc
-            AWData(AWType.region, [[iname.disc], [iname.weird_tricks, iname.bubble_long], [iname.weird_tricks, iname.wheel_hop, iname.ball], [iname.weird_tricks, iname.bubble, iname.ball]]),
+            AWData(AWType.region, [[iname.disc], [iname.obscure_tricks, iname.bubble_long], 
+                                   [iname.obscure_tricks, iname.wheel_hop, iname.ball, iname.ball_trick_medium], 
+                                   [iname.obscure_tricks, iname.bubble, iname.ball, iname.ball_trick_medium]]),
         rname.bobcat_room:
             AWData(AWType.region, [[iname.top]]), 
         lname.candle_fish:  # spike breaking presumed by access
@@ -294,8 +296,8 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         rname.bear_transcendental:  # might be controversial? it's across a screen transition but only 4 bubbles
             AWData(AWType.region, [[iname.bubble_short], [iname.disc_hop_hard]]),
         rname.bear_kangaroo_waterfall:
-            AWData(AWType.region, [[iname.slink], [iname.top, iname.yoyo], [iname.top, iname.ball],
-                                   [iname.ball, iname.weird_tricks]]),  # stand on left button, throw ball neutral
+            AWData(AWType.region, [[iname.slink], [iname.top, iname.yoyo],
+                                   [iname.ball, iname.ball_trick_easy]]),  # stand on left button, throw ball neutral
         rname.bear_razzle_egg_spot:
             AWData(AWType.region, [[iname.defeated_chameleon, iname.bubble_short],
                                    [iname.defeated_chameleon, iname.disc_hop_hard],


### PR DESCRIPTION
This PR removes weird_tricks as an option and replaces it with four more specific option types, which can be mixed and matched.

As of this PR, all of the work needed in options.py, names.py, and region_data.py has been performed. No changes have yet been made to the scripts that convert these iname tags into viable logic.