### PR TITLE
Animal Well: Deathlink foundations

### DIFF
--- a/worlds/animal_well/__init__.py
+++ b/worlds/animal_well/__init__.py
@@ -178,7 +178,7 @@ class AnimalWellWorld(World):
             "disc_hopping",
             "wheel_tricks",
             "weird_tricks",
-            "deathlink",
+            "death_link",
         )
 
     # for the universal tracker, doesn't get called in standard gen

--- a/worlds/animal_well/__init__.py
+++ b/worlds/animal_well/__init__.py
@@ -176,6 +176,7 @@ class AnimalWellWorld(World):
             "disc_hopping",
             "wheel_tricks",
             "weird_tricks",
+            "deathlink",
         )
 
     # for the universal tracker, doesn't get called in standard gen

--- a/worlds/animal_well/__init__.py
+++ b/worlds/animal_well/__init__.py
@@ -178,6 +178,7 @@ class AnimalWellWorld(World):
             "disc_hopping",
             "wheel_tricks",
             "weird_tricks",
+            "deathlink",
         )
 
     # for the universal tracker, doesn't get called in standard gen

--- a/worlds/animal_well/bean_patcher.py
+++ b/worlds/animal_well/bean_patcher.py
@@ -1,5 +1,5 @@
 from time import time
-from typing import List, Optional
+from typing import List, Optional, Callable
 
 from .patch import *
 
@@ -133,6 +133,12 @@ class Patch(Patch):
         """
         return self.mov_cl(sprite_id).call_via_rax(get_sprite)
 
+    def update_player_state(self, player, state, save):
+        """
+        Updates the player's state
+        """
+        return self.mov_rcx(player).mov_rdx(state).mov_r8(save).call_far(update_player_state)
+
 
 # region FunctionOffsets
 # Accurate as of AW file version 1.0.0.18
@@ -152,6 +158,7 @@ get_key_pressed: int = 0x140011C70
 get_gamepad_button_pressed: int = 0x140011EA0
 get_an_item: int = 0x1400C15C0
 warp: int = 0x140074DD0
+update_player_state: int = 0x1400662F0
 # endregion
 
 # region OtherOffsets
@@ -219,6 +226,10 @@ class BeanPatcher:
             self.logger.error(text)
         return self
 
+    def set_bean_death_function(self, function: Callable):
+        self.on_bean_death_function = function
+        return self
+
     def __init__(self, process=None, logger=None):
         self.process = process
         self.attached_to_process = False
@@ -239,6 +250,9 @@ class BeanPatcher:
         self.fullbright_patch: Patch
         self.room_palette_override_patch: Optional[Patch] = None
         self.room_palette_override_shader: int = 0x16
+
+        self.bean_has_died_address: int = 0
+        self.on_bean_death_function: Optional[Callable] = None
 
         self.draw_routine_string_size: int = 0
         self.game_draw_routine_string_addr = None
@@ -264,7 +278,8 @@ class BeanPatcher:
 
         self.fullbright_patch: Optional[Patch] = None
 
-    def get_current_save_slot(self):
+    @property
+    def current_save_slot(self):
         if not self.attached_to_process:
             self.log_error("Can't get current save slot without being attached to a process.")
             return None
@@ -274,8 +289,9 @@ class BeanPatcher:
 
         return self.process.read_uchar(self.application_state_address + 0x40C)
 
-    def get_current_save_address(self):
-        current_save_slot = self.get_current_save_slot()
+    @property
+    def current_save_address(self):
+        current_save_slot = self.current_save_slot
 
         if current_save_slot is None:
             self.log_error("Failed to get the current save slot.")
@@ -366,6 +382,8 @@ class BeanPatcher:
         self.apply_receive_item_patch()
 
         self.apply_skip_credits_patch()
+
+        self.apply_deathlink_patch()
 
         # mural bytes at slot + 0x26eaf
         # default mural bytes at 0x142094600
@@ -809,6 +827,51 @@ class BeanPatcher:
         if skip_credits_patch.apply():
             self.revertable_patches.append(skip_credits_patch)
 
+    def apply_deathlink_patch(self):
+        """
+        Sends a deathlink message when the bean is killed (by another that isn't deathlink)
+
+        Original code:
+        0x14003BA8A 48 89 F1                                mov     rcx, rsi                  ; player
+        0x14003BA8D B2 05                                   mov     dl, 5                     ; newPlayerState
+        0x14003BA8F 49 89 F8                                mov     r8, rdi                   ; save
+        0x14003BA92 E8 59 A8 02 00                          call    updatePlayerState
+        """
+        bean_died_address = self.module_base + 0x3BA8A
+
+        self.bean_has_died_address = self.custom_memory_current_offset
+
+        if self.log_debug_info:
+            self.log_info(f"bean_has_died_address: {hex(self.bean_has_died_address)}")
+
+        self.custom_memory_current_offset += 1
+
+        bean_died_routine_address = self.custom_memory_current_offset
+
+        bean_died_trampoline = (Patch("bean_died_trampoline", bean_died_address, self.process)
+                           .mov_to_rax(bean_died_routine_address)
+                           .jmp_rax()
+                           )
+
+        bean_died_routine = (Patch("bean_died_routine", bean_died_routine_address, self.process)
+                             .mov_to_al(1)
+                             .mov_rbx(self.bean_has_died_address)
+                             .mov_al_to_address_in_rbx()
+                             .update_player_state(self.player_address, 5, self.current_save_address)
+                             .jmp_far(self.module_base + 0x3BA97)
+                             )
+
+        self.custom_memory_current_offset += len(bean_died_routine)
+
+        if self.log_debug_info:
+            self.log_info(f"Applying deathlink patch...\n{bean_died_routine}")
+
+        if bean_died_routine.apply():
+            self.revertable_patches.append(bean_died_routine)
+
+        if bean_died_trampoline.apply():
+            self.revertable_patches.append(bean_died_trampoline)
+
     def enable_fullbright(self) -> None:
         if self.fullbright_patch is None or self.fullbright_patch.patch_applied:
             return None
@@ -898,6 +961,12 @@ class BeanPatcher:
             if time() - self.last_message_time >= self.message_timeout:
                 self.display_to_client("")
 
+        if self.bean_has_died_address != 0:
+            if self.process.read_bool(self.bean_has_died_address):
+                self.process.write_bool(self.bean_has_died_address, False)
+                if self.on_bean_death_function is not None:
+                    self.on_bean_death_function()
+
     def display_dialog(self, text: str, title: str = "", action_text: str = ""):
         try:
             if self.process is not None and self.application_state_address is not None:
@@ -926,3 +995,10 @@ class BeanPatcher:
                     self.last_message_time = 0
         except Exception as e:
             self.log_error(f"Error while attempting to display text to client: {e}")
+
+    def set_player_state(self, state: int):
+        try:
+            if self.attached_to_process and self.application_state_address:
+                self.process.write_uchar(self.player_address + 0x5d, state)
+        except Exception as e:
+            self.log_error(f"Error while attempting to set player state: {e}")

--- a/worlds/animal_well/bean_patcher.py
+++ b/worlds/animal_well/bean_patcher.py
@@ -1,5 +1,5 @@
 from time import time
-from typing import List, Optional
+from typing import List, Optional, Callable
 
 from .patch import *
 
@@ -133,6 +133,12 @@ class Patch(Patch):
         """
         return self.mov_cl(sprite_id).call_via_rax(get_sprite)
 
+    def update_player_state(self, player, state, save):
+        """
+        Updates the player's state
+        """
+        return self.mov_rcx(player).mov_rdx(state).mov_r8(save).call_far(update_player_state)
+
 
 # region FunctionOffsets
 # Accurate as of AW file version 1.0.0.18
@@ -152,6 +158,7 @@ get_key_pressed: int = 0x140011C70
 get_gamepad_button_pressed: int = 0x140011EA0
 get_an_item: int = 0x1400C15C0
 warp: int = 0x140074DD0
+update_player_state: int = 0x1400662F0
 # endregion
 
 # region OtherOffsets
@@ -219,6 +226,10 @@ class BeanPatcher:
             self.logger.error(text)
         return self
 
+    def set_bean_death_function(self, function: Callable):
+        self.on_bean_death_function = function
+        return self
+
     def __init__(self, process=None, logger=None):
         self.process = process
         self.attached_to_process = False
@@ -239,6 +250,9 @@ class BeanPatcher:
         self.fullbright_patch: Patch
         self.room_palette_override_patch: Optional[Patch] = None
         self.room_palette_override_shader: int = 0x16
+
+        self.bean_has_died_address: int = 0
+        self.on_bean_death_function: Optional[Callable] = None
 
         self.draw_routine_string_size: int = 0
         self.game_draw_routine_string_addr = None
@@ -264,7 +278,8 @@ class BeanPatcher:
 
         self.fullbright_patch: Optional[Patch] = None
 
-    def get_current_save_slot(self):
+    @property
+    def current_save_slot(self):
         if not self.attached_to_process:
             self.log_error("Can't get current save slot without being attached to a process.")
             return None
@@ -274,8 +289,9 @@ class BeanPatcher:
 
         return self.process.read_uchar(self.application_state_address + 0x40C)
 
-    def get_current_save_address(self):
-        current_save_slot = self.get_current_save_slot()
+    @property
+    def current_save_address(self):
+        current_save_slot = self.current_save_slot
 
         if current_save_slot is None:
             self.log_error("Failed to get the current save slot.")
@@ -366,6 +382,8 @@ class BeanPatcher:
         self.apply_receive_item_patch()
 
         self.apply_skip_credits_patch()
+
+        self.apply_deathlink_patch()
 
         # mural bytes at slot + 0x26eaf
         # default mural bytes at 0x142094600
@@ -818,6 +836,51 @@ class BeanPatcher:
         if skip_credits_patch.apply():
             self.revertable_patches.append(skip_credits_patch)
 
+    def apply_deathlink_patch(self):
+        """
+        Sends a deathlink message when the bean is killed (by another that isn't deathlink)
+
+        Original code:
+        0x14003BA8A 48 89 F1                                mov     rcx, rsi                  ; player
+        0x14003BA8D B2 05                                   mov     dl, 5                     ; newPlayerState
+        0x14003BA8F 49 89 F8                                mov     r8, rdi                   ; save
+        0x14003BA92 E8 59 A8 02 00                          call    updatePlayerState
+        """
+        bean_died_address = self.module_base + 0x3BA8A
+
+        self.bean_has_died_address = self.custom_memory_current_offset
+
+        if self.log_debug_info:
+            self.log_info(f"bean_has_died_address: {hex(self.bean_has_died_address)}")
+
+        self.custom_memory_current_offset += 1
+
+        bean_died_routine_address = self.custom_memory_current_offset
+
+        bean_died_trampoline = (Patch("bean_died_trampoline", bean_died_address, self.process)
+                           .mov_to_rax(bean_died_routine_address)
+                           .jmp_rax()
+                           )
+
+        bean_died_routine = (Patch("bean_died_routine", bean_died_routine_address, self.process)
+                             .mov_to_al(1)
+                             .mov_rbx(self.bean_has_died_address)
+                             .mov_al_to_address_in_rbx()
+                             .update_player_state(self.player_address, 5, self.current_save_address)
+                             .jmp_far(self.module_base + 0x3BA97)
+                             )
+
+        self.custom_memory_current_offset += len(bean_died_routine)
+
+        if self.log_debug_info:
+            self.log_info(f"Applying deathlink patch...\n{bean_died_routine}")
+
+        if bean_died_routine.apply():
+            self.revertable_patches.append(bean_died_routine)
+
+        if bean_died_trampoline.apply():
+            self.revertable_patches.append(bean_died_trampoline)
+
     def enable_fullbright(self) -> None:
         if self.fullbright_patch is None or self.fullbright_patch.patch_applied:
             return None
@@ -907,6 +970,12 @@ class BeanPatcher:
             if time() - self.last_message_time >= self.message_timeout:
                 self.display_to_client("")
 
+        if self.bean_has_died_address != 0:
+            if self.process.read_bool(self.bean_has_died_address):
+                self.process.write_bool(self.bean_has_died_address, False)
+                if self.on_bean_death_function is not None:
+                    self.on_bean_death_function()
+
     def display_dialog(self, text: str, title: str = "", action_text: str = ""):
         try:
             if self.process is not None and self.application_state_address is not None:
@@ -935,3 +1004,10 @@ class BeanPatcher:
                     self.last_message_time = 0
         except Exception as e:
             self.log_error(f"Error while attempting to display text to client: {e}")
+
+    def set_player_state(self, state: int):
+        try:
+            if self.attached_to_process and self.application_state_address:
+                self.process.write_uchar(self.player_address + 0x5d, state)
+        except Exception as e:
+            self.log_error(f"Error while attempting to set player state: {e}")

--- a/worlds/animal_well/bean_patcher.py
+++ b/worlds/animal_well/bean_patcher.py
@@ -1,5 +1,5 @@
 from time import time
-from typing import List, Optional, Callable
+from typing import List, Optional, Callable, Any, Awaitable
 
 from .patch import *
 
@@ -252,7 +252,7 @@ class BeanPatcher:
         self.room_palette_override_shader: int = 0x16
 
         self.bean_has_died_address: int = 0
-        self.on_bean_death_function: Optional[Callable] = None
+        self.on_bean_death_function: Optional[Callable[[Any], Awaitable[Any]]] = None
 
         self.draw_routine_string_size: int = 0
         self.game_draw_routine_string_addr = None
@@ -956,7 +956,7 @@ class BeanPatcher:
             self.process.write_uint(self.game_draw_symbol_x_address, self.player_position_history[0][0])
             self.process.write_uint(self.game_draw_symbol_y_address, self.player_position_history[0][1])
 
-    def tick(self):
+    async def tick(self):
         if self.last_message_time != 0:
             if time() - self.last_message_time >= self.message_timeout:
                 self.display_to_client("")
@@ -965,7 +965,7 @@ class BeanPatcher:
             if self.process.read_bool(self.bean_has_died_address):
                 self.process.write_bool(self.bean_has_died_address, False)
                 if self.on_bean_death_function is not None:
-                    self.on_bean_death_function()
+                    await self.on_bean_death_function()
 
     def display_dialog(self, text: str, title: str = "", action_text: str = ""):
         try:

--- a/worlds/animal_well/bean_patcher.py
+++ b/worlds/animal_well/bean_patcher.py
@@ -1,5 +1,5 @@
 from time import time
-from typing import List, Optional, Callable
+from typing import List, Optional, Callable, Any, Awaitable
 
 from .patch import *
 
@@ -252,7 +252,7 @@ class BeanPatcher:
         self.room_palette_override_shader: int = 0x16
 
         self.bean_has_died_address: int = 0
-        self.on_bean_death_function: Optional[Callable] = None
+        self.on_bean_death_function: Optional[Callable[[Any], Awaitable[Any]]] = None
 
         self.draw_routine_string_size: int = 0
         self.game_draw_routine_string_addr = None
@@ -965,7 +965,7 @@ class BeanPatcher:
             self.process.write_uint(self.game_draw_symbol_x_address, self.player_position_history[0][0])
             self.process.write_uint(self.game_draw_symbol_y_address, self.player_position_history[0][1])
 
-    def tick(self):
+    async def tick(self):
         if self.last_message_time != 0:
             if time() - self.last_message_time >= self.message_timeout:
                 self.display_to_client("")
@@ -974,7 +974,7 @@ class BeanPatcher:
             if self.process.read_bool(self.bean_has_died_address):
                 self.process.write_bool(self.bean_has_died_address, False)
                 if self.on_bean_death_function is not None:
-                    self.on_bean_death_function()
+                    await self.on_bean_death_function()
 
     def display_dialog(self, text: str, title: str = "", action_text: str = ""):
         try:

--- a/worlds/animal_well/client.py
+++ b/worlds/animal_well/client.py
@@ -44,6 +44,20 @@ class AnimalWellCommandProcessor(ClientCommandProcessor):
         if isinstance(self.ctx, AnimalWellContext):
             logger.info(f"Animal Well Connection Status: {self.ctx.connection_status}")
 
+    def _cmd_set_player_state(self, val="0"):
+        if isinstance(self.ctx, AnimalWellContext):
+            if not val.isnumeric():
+                logger.info(f"Invalid player state input: {val}. Please use a number between 0 and 255")
+                return
+
+            val = int(val)
+
+            if val > 0xff:
+                logger.info(f"Invalid player state input: {val}. Please use a number between 0 and 255")
+                return
+
+            self.ctx.bean_patcher.set_player_state(int(val))
+
     def _cmd_room_palette(self, val=""):
         """
         Sets an override for room palettes. Accepts a number between 0 and 31, "off" to disable, or "random" to pick a room palette at random.
@@ -187,8 +201,8 @@ class AnimalWellContext(CommonContext):
             self.bean_patcher.display_to_client(text)
 
     async def on_bean_death(self):
-        self.display_text_in_client("You died")
-        if self.slot_data.get("deathlink", None) == 1:
+        self.display_text_in_client("You died.")
+        if self.slot_data.get("death_link", None) == 1:
             await self.send_death("BEAN DEAD.")
 
     async def server_auth(self, password_requested: bool = False):

--- a/worlds/animal_well/client.py
+++ b/worlds/animal_well/client.py
@@ -79,6 +79,22 @@ class AnimalWellCommandProcessor(ClientCommandProcessor):
                 logger.info(f"Enabling fullbright...")
                 self.ctx.bean_patcher.enable_fullbright()
 
+    def _cmd_deathlink(self, val=""):
+        """
+        Toggles deathlink.
+        """
+        if isinstance(self.ctx, AnimalWellContext):
+            if val == "":
+                self.ctx.slot_data["deathlink"] = (0 if self.ctx.slot_data.get("deathlink", None) == 1 else 1)
+            elif val == "off":
+                self.ctx.slot_data["deathlink"] = 0
+            elif val == "on":
+                self.ctx.slot_data["deathlink"] = 1
+
+            status_text = "Deathlink is now " + ("ENABLED" if self.ctx.slot_data.get("deathlink", None) == 1 else "DISABLED")
+            self.ctx.display_text_in_client(status_text)
+            logger.info(status_text)
+
     def _cmd_ring(self):
         """Toggles the cheater's ring in your inventory to allow noclip and get unstuck"""
         try:
@@ -325,7 +341,7 @@ class AnimalWellContext(CommonContext):
             elif cmd == "Bounced":
                 tags = args.get("tags", [])
 
-                if "DeathLink" in tags and self.last_death_link != args["data"]["time"]:
+                if "DeathLink" in tags and self.last_death_link != args["data"]["time"] and self.slot_data.get("deathlink", None) == 1:
                     self.on_deathlink(args["data"])
 
         except Exception as e:

--- a/worlds/animal_well/client.py
+++ b/worlds/animal_well/client.py
@@ -18,7 +18,7 @@ from typing import Dict
 from .items import item_name_to_id, item_name_groups
 from .locations import location_name_to_id, location_table, ByteSect
 from .names import ItemNames as iname, LocationNames as lname
-from .options import FinalEggLocation, Goal
+from .options import FinalEggLocation, Goal, Deathlink
 from .bean_patcher import BeanPatcher
 from .logic_tracker import AnimalWellTracker, CheckStatus
 
@@ -204,6 +204,9 @@ class AnimalWellContext(CommonContext):
 
     def on_bean_death(self):
         self.display_text_in_client("You died")
+        if self.slot_data.get("deathlink", None):
+            #Send Deathlink Package
+            pass
 
     async def server_auth(self, password_requested: bool = False):
         """

--- a/worlds/animal_well/client.py
+++ b/worlds/animal_well/client.py
@@ -18,7 +18,7 @@ from typing import Dict
 from .items import item_name_to_id, item_name_groups
 from .locations import location_name_to_id, location_table, ByteSect
 from .names import ItemNames as iname, LocationNames as lname
-from .options import FinalEggLocation, Goal
+from .options import FinalEggLocation, Goal, Deathlink
 from .bean_patcher import BeanPatcher
 from .logic_tracker import AnimalWellTracker, CheckStatus, candle_event_to_item
 
@@ -194,6 +194,9 @@ class AnimalWellContext(CommonContext):
 
     def on_bean_death(self):
         self.display_text_in_client("You died")
+        if self.slot_data.get("deathlink", None):
+            #Send Deathlink Package
+            pass
 
     async def server_auth(self, password_requested: bool = False):
         """

--- a/worlds/animal_well/client.py
+++ b/worlds/animal_well/client.py
@@ -192,7 +192,7 @@ class AnimalWellContext(CommonContext):
 
     async def on_bean_death(self):
         self.display_text_in_client("You died")
-        if self.slot_data.get("deathlink", None) == 1:
+        if self.slot_data.get("death_link", None) == 1:
             await self.send_death("BEAN DEAD.")
 
     async def server_auth(self, password_requested: bool = False):

--- a/worlds/animal_well/client.py
+++ b/worlds/animal_well/client.py
@@ -44,20 +44,6 @@ class AnimalWellCommandProcessor(ClientCommandProcessor):
         if isinstance(self.ctx, AnimalWellContext):
             logger.info(f"Animal Well Connection Status: {self.ctx.connection_status}")
 
-    def _cmd_set_player_state(self, val="0"):
-        if isinstance(self.ctx, AnimalWellContext):
-            if not val.isnumeric():
-                logger.info(f"Invalid player state input: {val}. Please use a number between 0 and 255")
-                return
-
-            val = int(val)
-
-            if val > 0xff:
-                logger.info(f"Invalid player state input: {val}. Please use a number between 0 and 255")
-                return
-
-            self.ctx.bean_patcher.set_player_state(int(val))
-
     def _cmd_room_palette(self, val=""):
         """
         Sets an override for room palettes. Accepts a number between 0 and 31, "off" to disable, or "random" to pick a room palette at random.
@@ -201,8 +187,8 @@ class AnimalWellContext(CommonContext):
             self.bean_patcher.display_to_client(text)
 
     async def on_bean_death(self):
-        self.display_text_in_client("You died.")
-        if self.slot_data.get("death_link", None) == 1:
+        self.display_text_in_client("You died")
+        if self.slot_data.get("deathlink", None) == 1:
             await self.send_death("BEAN DEAD.")
 
     async def server_auth(self, password_requested: bool = False):

--- a/worlds/animal_well/client.py
+++ b/worlds/animal_well/client.py
@@ -14,7 +14,7 @@ import pymem
 import Utils
 from CommonClient import CommonContext, server_loop, gui_enabled, ClientCommandProcessor, logger, get_base_parser
 from NetUtils import ClientStatus
-from typing import Dict
+from typing import Dict, Any
 from .items import item_name_to_id, item_name_groups
 from .locations import location_name_to_id, location_table, ByteSect
 from .names import ItemNames as iname, LocationNames as lname
@@ -195,8 +195,7 @@ class AnimalWellContext(CommonContext):
     def on_bean_death(self):
         self.display_text_in_client("You died")
         if self.slot_data.get("deathlink", None):
-            #Send Deathlink Package
-            pass
+            self.send_death()
 
     async def server_auth(self, password_requested: bool = False):
         """
@@ -332,6 +331,10 @@ class AnimalWellContext(CommonContext):
         except Exception as e:
             logger.error("Error while parsing Package from AP: %s", e)
             logger.info("Package details: {}".format(args))
+
+    def on_deathlink(self, data: Dict[str, Any]) -> None:
+        self.bean_patcher.set_player_state(5)
+        return super().on_deathlink(data)
 
     def get_active_game_slot(self) -> int:
         """

--- a/worlds/animal_well/client.py
+++ b/worlds/animal_well/client.py
@@ -233,7 +233,7 @@ class AnimalWellContext(CommonContext):
             for location_id in args.get("checked_locations"):
                 location_name = self.location_names.lookup_in_slot(location_id)
                 self.logic_tracker.check_logic_status[location_name] = CheckStatus.checked.value
-            Utils.async_start(self.update_death_link(self.slot_data.get("deathlink", None) == 1))
+            Utils.async_start(self.update_death_link(self.slot_data.get("death_link", None) == 1))
 
         try:
             if cmd == "PrintJSON":

--- a/worlds/animal_well/client.py
+++ b/worlds/animal_well/client.py
@@ -229,6 +229,7 @@ class AnimalWellContext(CommonContext):
             for location_id in args.get("checked_locations"):
                 location_name = self.location_names.lookup_in_slot(location_id)
                 self.logic_tracker.check_logic_status[location_name] = CheckStatus.checked.value
+            Utils.async_start(self.update_death_link(self.slot_data.get("deathlink", None) == 1))
 
         try:
             if cmd == "PrintJSON":

--- a/worlds/animal_well/client.py
+++ b/worlds/animal_well/client.py
@@ -14,7 +14,7 @@ import pymem
 import Utils
 from CommonClient import CommonContext, server_loop, gui_enabled, ClientCommandProcessor, logger, get_base_parser
 from NetUtils import ClientStatus
-from typing import Dict
+from typing import Dict, Any
 from .items import item_name_to_id, item_name_groups
 from .locations import location_name_to_id, location_table, ByteSect
 from .names import ItemNames as iname, LocationNames as lname
@@ -205,8 +205,7 @@ class AnimalWellContext(CommonContext):
     def on_bean_death(self):
         self.display_text_in_client("You died")
         if self.slot_data.get("deathlink", None):
-            #Send Deathlink Package
-            pass
+            self.send_death()
 
     async def server_auth(self, password_requested: bool = False):
         """
@@ -340,6 +339,10 @@ class AnimalWellContext(CommonContext):
         except Exception as e:
             logger.error("Error while parsing Package from AP: %s", e)
             logger.info("Package details: {}".format(args))
+
+    def on_deathlink(self, data: Dict[str, Any]) -> None:
+        self.bean_patcher.set_player_state(5)
+        return super().on_deathlink(data)
 
     def get_active_game_slot(self) -> int:
         """

--- a/worlds/animal_well/client.py
+++ b/worlds/animal_well/client.py
@@ -212,7 +212,6 @@ class AnimalWellContext(CommonContext):
             self.bean_patcher.display_to_client(text)
 
     async def on_bean_death(self):
-        self.display_text_in_client("You died")
         if self.slot_data.get("death_link", None) == 1:
             await self.send_death(DEATHLINK_MESSAGE)
 

--- a/worlds/animal_well/client.py
+++ b/worlds/animal_well/client.py
@@ -239,6 +239,7 @@ class AnimalWellContext(CommonContext):
             for location_id in args.get("checked_locations"):
                 location_name = self.location_names.lookup_in_slot(location_id)
                 self.logic_tracker.check_logic_status[location_name] = CheckStatus.checked.value
+            Utils.async_start(self.update_death_link(self.slot_data.get("deathlink", None) == 1))
 
         try:
             if cmd == "PrintJSON":

--- a/worlds/animal_well/client.py
+++ b/worlds/animal_well/client.py
@@ -43,6 +43,20 @@ class AnimalWellCommandProcessor(ClientCommandProcessor):
         if isinstance(self.ctx, AnimalWellContext):
             logger.info(f"Animal Well Connection Status: {self.ctx.connection_status}")
 
+    def _cmd_set_player_state(self, val="0"):
+        if isinstance(self.ctx, AnimalWellContext):
+            if not val.isnumeric():
+                logger.info(f"Invalid player state input: {val}. Please use a number between 0 and 255")
+                return
+
+            val = int(val)
+
+            if val > 0xff:
+                logger.info(f"Invalid player state input: {val}. Please use a number between 0 and 255")
+                return
+
+            self.ctx.bean_patcher.set_player_state(int(val))
+
     def _cmd_room_palette(self, val=""):
         if isinstance(self.ctx, AnimalWellContext):
             if val == "":
@@ -174,7 +188,9 @@ class AnimalWellContext(CommonContext):
         self.first_m_disc = True
         self.used_firecrackers = 0
         self.used_berries = 0
-        self.bean_patcher = BeanPatcher().set_logger(logger)
+        self.bean_patcher = BeanPatcher()
+        self.bean_patcher.set_logger(logger)
+        self.bean_patcher.set_bean_death_function(self.on_bean_death)
         self.bean_patcher.game_draw_routine_default_string = "Connected to the well..."
         self.logic_tracker = AnimalWellTracker()
 
@@ -185,6 +201,9 @@ class AnimalWellContext(CommonContext):
     def display_text_in_client(self, text: str):
         if self.bean_patcher is not None and self.bean_patcher.attached_to_process:
             self.bean_patcher.display_to_client(text)
+
+    def on_bean_death(self):
+        self.display_text_in_client("You died")
 
     async def server_auth(self, password_requested: bool = False):
         """

--- a/worlds/animal_well/client.py
+++ b/worlds/animal_well/client.py
@@ -31,6 +31,7 @@ CONNECTION_TENTATIVE_STATUS = "Connection has been initiated"
 CONNECTION_INITIAL_STATUS = "Connection has not been initiated"
 
 DEATHLINK_MESSAGE = "The bean has died."
+DEATHLINK_RECEIVED_MESSAGE = "{name} died and took you with them."
 
 HEADER_LENGTH = 0x18
 SAVE_SLOT_LENGTH = 0x27010
@@ -358,12 +359,14 @@ class AnimalWellContext(CommonContext):
 
     def on_deathlink(self, data: Dict[str, Any]) -> None:
         self.last_death_link = max(data["time"], self.last_death_link)
-        text = data.get("cause", "")
+        text = DEATHLINK_RECEIVED_MESSAGE.replace("{name}", data.get("source", "A Player"))
+        cause = data.get("cause", None)
 
-        if text:
-            logger.info(f"DeathLink: {text}")
-        else:
-            logger.info(f"DeathLink: Received from {data['source']}")
+        if cause is not None:
+            text = cause
+
+        logger.info(text)
+        self.display_text_in_client(text)
         self.bean_patcher.set_player_state(5)
 
     def get_active_game_slot(self) -> int:

--- a/worlds/animal_well/client.py
+++ b/worlds/animal_well/client.py
@@ -7,6 +7,7 @@ import asyncio
 import os
 import platform
 import random
+import time
 import traceback
 
 import pymem
@@ -43,21 +44,10 @@ class AnimalWellCommandProcessor(ClientCommandProcessor):
         if isinstance(self.ctx, AnimalWellContext):
             logger.info(f"Animal Well Connection Status: {self.ctx.connection_status}")
 
-    def _cmd_set_player_state(self, val="0"):
-        if isinstance(self.ctx, AnimalWellContext):
-            if not val.isnumeric():
-                logger.info(f"Invalid player state input: {val}. Please use a number between 0 and 255")
-                return
-
-            val = int(val)
-
-            if val > 0xff:
-                logger.info(f"Invalid player state input: {val}. Please use a number between 0 and 255")
-                return
-
-            self.ctx.bean_patcher.set_player_state(int(val))
-
     def _cmd_room_palette(self, val=""):
+        """
+        Sets an override for room palettes. Accepts a number between 0 and 31, "off" to disable, or "random" to pick a room palette at random.
+        """
         if isinstance(self.ctx, AnimalWellContext):
             if val == "":
                 self.ctx.bean_patcher.toggle_room_palette_override()
@@ -76,6 +66,9 @@ class AnimalWellCommandProcessor(ClientCommandProcessor):
                 self.ctx.bean_patcher.enable_room_palette_override(0x14)
 
     def _cmd_fullbright(self, val=""):
+        """
+        Toggles fullbright mode, which disabled darkness and lights all tiles equally.
+        """
         if isinstance(self.ctx, AnimalWellContext):
             if val == "":
                 self.ctx.bean_patcher.toggle_fullbright()
@@ -183,6 +176,7 @@ class AnimalWellContext(CommonContext):
         self.slot_number: int = -1
         self.current_game_state = -1
         self.last_game_state = -1
+        self.last_death_link: float = time.time()
         # used to delay starting the loop until we can see the data storage values
         self.got_data_storage: bool = False
         self.first_m_disc = True
@@ -202,10 +196,10 @@ class AnimalWellContext(CommonContext):
         if self.bean_patcher is not None and self.bean_patcher.attached_to_process:
             self.bean_patcher.display_to_client(text)
 
-    def on_bean_death(self):
+    async def on_bean_death(self):
         self.display_text_in_client("You died")
-        if self.slot_data.get("deathlink", None):
-            self.send_death()
+        if self.slot_data.get("deathlink", None) == 1:
+            await self.send_death("BEAN DEAD.")
 
     async def server_auth(self, password_requested: bool = False):
         """
@@ -335,14 +329,25 @@ class AnimalWellContext(CommonContext):
                 pass
             elif cmd == "None":
                 self.display_text_in_client(args.get("data")[0]["text"])
+            elif cmd == "Bounced":
+                tags = args.get("tags", [])
+
+                if "DeathLink" in tags and self.last_death_link != args["data"]["time"]:
+                    self.on_deathlink(args["data"])
 
         except Exception as e:
             logger.error("Error while parsing Package from AP: %s", e)
             logger.info("Package details: {}".format(args))
 
     def on_deathlink(self, data: Dict[str, Any]) -> None:
+        self.last_death_link = max(data["time"], self.last_death_link)
+        text = data.get("cause", "")
+
+        if text:
+            logger.info(f"DeathLink: {text}")
+        else:
+            logger.info(f"DeathLink: Received from {data['source']}")
         self.bean_patcher.set_player_state(5)
-        return super().on_deathlink(data)
 
     def get_active_game_slot(self) -> int:
         """
@@ -1245,7 +1250,7 @@ async def process_sync_task(ctx: AnimalWellContext):
             items.write_to_game(ctx)
 
             if ctx.bean_patcher is not None and ctx.bean_patcher.attached_to_process:
-                ctx.bean_patcher.tick()
+                await ctx.bean_patcher.tick()
 
         await asyncio.sleep(0.1)
 

--- a/worlds/animal_well/options.py
+++ b/worlds/animal_well/options.py
@@ -163,6 +163,12 @@ class WheelHopping(Choice):
     default = 0
     visibility = Visibility.none
 
+class Deathlink(Choice):
+    """
+    Dying causes other players to die. If other players die, you die.
+    """
+    internal_name = "deathlink"
+    display_name = "Deathlink"
 
 @dataclass
 class AnimalWellOptions(PerGameCommonOptions):
@@ -180,6 +186,7 @@ class AnimalWellOptions(PerGameCommonOptions):
     wheel_tricks: WheelTricks
     weird_tricks: WeirdTricks
     exclude_song_chests: ExcludeSongChests
+    deathlink: Deathlink
 
     wheel_hopping: WheelHopping
 
@@ -200,6 +207,7 @@ aw_option_presets: Dict[str, Dict[str, Any]] = {
         "disc_hopping": DiscHopping.option_multiple,
         "wheel_tricks": WheelTricks.option_advanced,
         "weird_tricks": True,
-        "bunnies_as_checks": BunniesAsChecks.option_all_bunnies
+        "bunnies_as_checks": BunniesAsChecks.option_all_bunnies,
+        "deathlink": False
     },
 }

--- a/worlds/animal_well/options.py
+++ b/worlds/animal_well/options.py
@@ -163,7 +163,7 @@ class WheelHopping(Choice):
     default = 0
     visibility = Visibility.none
 
-class Deathlink(Choice):
+class Deathlink(Toggle):
     """
     Dying causes other players to die. If other players die, you die.
     """

--- a/worlds/animal_well/options.py
+++ b/worlds/animal_well/options.py
@@ -186,7 +186,7 @@ class AnimalWellOptions(PerGameCommonOptions):
     wheel_tricks: WheelTricks
     weird_tricks: WeirdTricks
     exclude_song_chests: ExcludeSongChests
-    deathlink: Deathlink
+    death_link: DeathLink
 
     wheel_hopping: WheelHopping
 

--- a/worlds/animal_well/options.py
+++ b/worlds/animal_well/options.py
@@ -208,6 +208,5 @@ aw_option_presets: Dict[str, Dict[str, Any]] = {
         "wheel_tricks": WheelTricks.option_advanced,
         "weird_tricks": True,
         "bunnies_as_checks": BunniesAsChecks.option_all_bunnies,
-        "deathlink": False
     },
 }

--- a/worlds/animal_well/options.py
+++ b/worlds/animal_well/options.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Dict, Any
 from Options import (DefaultOnToggle, Toggle, StartInventoryPool, Choice, Range, PerGameCommonOptions, OptionGroup,
-                     Visibility)
+                     Visibility, DeathLink)
 
 
 class Goal(Choice):
@@ -162,13 +162,6 @@ class WheelHopping(Choice):
     option_advanced = 2
     default = 0
     visibility = Visibility.none
-
-class Deathlink(Toggle):
-    """
-    Dying causes other players to die. If other players die, you die.
-    """
-    internal_name = "deathlink"
-    display_name = "Deathlink"
 
 @dataclass
 class AnimalWellOptions(PerGameCommonOptions):

--- a/worlds/animal_well/patch.py
+++ b/worlds/animal_well/patch.py
@@ -432,6 +432,20 @@ class Patch:
         """
         return self.je_near(7).jmp_near_offset(0x0e).jmp_far(address)
 
+    def mov_to_al(self, value):
+        """
+        Moves an 8-bit value to AL
+        2 bytes
+        """
+        return self.add_bytes(b'\xb0' + value.to_bytes(1, 'little'))
+
+    def mov_to_ax(self, value):
+        """
+        Moves a 16-bit value to EAX
+        4 bytes
+        """
+        return self.add_bytes(b'\x66\xb8' + value.to_bytes(2, 'little'))
+
     def mov_to_eax(self, value):
         """
         Moves a 32-bit value to EAX
@@ -487,6 +501,27 @@ class Patch:
         3 bytes
         """
         return self.add_bytes(b'\x48\x8b\x10')
+
+    def mov_al_to_address_in_rbx(self):
+        """
+        Moves an 8-bit value from AL to the address specified in RBX
+        2 bytes
+        """
+        return self.add_bytes(b'\x88\x03')
+
+    def mov_ax_to_address_in_rbx(self):
+        """
+        Moves a 16-bit value from AX to the address specified in RBX
+        3 bytes
+        """
+        return self.add_bytes(b'\x66\x89\x03')
+
+    def mov_eax_to_address_in_rbx(self):
+        """
+        Moves a 32-bit value from EAX to the address specified in RBX
+        2 bytes
+        """
+        return self.add_bytes(b'\x89\x03')
 
     def mov_rax_to_address_in_rbx(self):
         """


### PR DESCRIPTION
## What is this fixing or adding?
Added method to change player's state. This can be triggered manually for test purposes via the command /set_player_state. Added deathlink patch that triggers a function that you can set on BeanPatcher whenever the player dies due to in-game causes (not triggered by deathlink). As a placeholder, I've defaulted it to a function that displays the text "You died" to the player.

Remaining steps:
Add an on_package conditional for receiving a deathlink with which we can trigger set_player_state(5) to cause the player to die.
Replace the placeholder `on_bean_death` function with one that sends a deathlink, if the appropriate setting was set in the YAML.

## How was this tested?


## If this makes graphical changes, please attach screenshots.
