### PR TITLE
Patch Mock Disc chest flags check, patch firecracker pickup dialog, small QoL fixes

### DIFF
--- a/worlds/animal_well/bean_patcher.py
+++ b/worlds/animal_well/bean_patcher.py
@@ -712,6 +712,8 @@ class BeanPatcher:
         disable_egg65_get_dialog_patch = Patch("disable_egg65_get_dialog", 0x1400c18be, self.process).nop(5)
         disable_bbwand_get_dialog_patch = Patch("disable_bbwand_get_dialog", 0x1400c1d75, self.process).nop(5)
         disable_fannypack_get_dialog_patch = Patch("disable_fannypack_get_dialog", 0x1400c1e81, self.process).nop(5)
+        disable_firecracker_get_dialog_patch = Patch("disable_firecracker_get_dialog", 0x14002cb59, self.process).nop(5)
+        disable_mockdisc_flags_check_patch = Patch("disable_mockdisc_flags_check", 0x1400c1003, self.process).add_bytes(bytearray([0xEB]))
         if self.log_debug_info:
             self.log_info(f"Applying disable_chest_item_patch patch...\n{disable_chest_item_patch}")
         if disable_chest_item_patch.apply():
@@ -750,6 +752,10 @@ class BeanPatcher:
             self.revertable_patches.append(disable_bbwand_get_dialog_patch)
         if disable_fannypack_get_dialog_patch.apply():
             self.revertable_patches.append(disable_fannypack_get_dialog_patch)
+        if disable_firecracker_get_dialog_patch.apply():
+            self.revertable_patches.append(disable_firecracker_get_dialog_patch)
+        if disable_mockdisc_flags_check_patch.apply():
+            self.revertable_patches.append(disable_mockdisc_flags_check_patch)
 
     def apply_receive_item_patch(self):
         """

--- a/worlds/animal_well/bean_patcher.py
+++ b/worlds/animal_well/bean_patcher.py
@@ -713,6 +713,7 @@ class BeanPatcher:
         disable_bbwand_get_dialog_patch = Patch("disable_bbwand_get_dialog", 0x1400c1d75, self.process).nop(5)
         disable_fannypack_get_dialog_patch = Patch("disable_fannypack_get_dialog", 0x1400c1e81, self.process).nop(5)
         disable_firecracker_get_dialog_patch = Patch("disable_firecracker_get_dialog", 0x14002cb59, self.process).nop(5)
+        disable_firecracker_selected_equipment_patch = Patch("disable_firecracker_selected_equipment", 0x14002caea, self.process).nop(5)
         disable_mockdisc_flags_check_patch = Patch("disable_mockdisc_flags_check", 0x1400c1003, self.process).add_bytes(bytearray([0xEB]))
         if self.log_debug_info:
             self.log_info(f"Applying disable_chest_item_patch patch...\n{disable_chest_item_patch}")
@@ -754,6 +755,8 @@ class BeanPatcher:
             self.revertable_patches.append(disable_fannypack_get_dialog_patch)
         if disable_firecracker_get_dialog_patch.apply():
             self.revertable_patches.append(disable_firecracker_get_dialog_patch)
+        if disable_firecracker_selected_equipment_patch.apply():
+            self.revertable_patches.append(disable_firecracker_selected_equipment_patch)
         if disable_mockdisc_flags_check_patch.apply():
             self.revertable_patches.append(disable_mockdisc_flags_check_patch)
 

--- a/worlds/animal_well/client.py
+++ b/worlds/animal_well/client.py
@@ -865,7 +865,8 @@ class AWItems:
 
                 # Write Keys
                 if self.key_ring:
-                    buffer = bytes([1])
+                    # always show real amount of key doors left unopened for a quick and easy way to check how many you have left
+                    buffer = bytes([max(0, 6 - keys_used)])
                 else:
                     buffer = bytes([max(0, self.key - keys_used)])
                 ctx.process_handle.write_bytes(slot_address + 0x1B1, buffer, 1)
@@ -885,7 +886,8 @@ class AWItems:
 
                 # Write Matches
                 if self.matchbox:
-                    buffer = bytes([1])
+                    # always show real amount of candles left unlit for a quick and easy way to check how many you have left
+                    buffer = bytes([max(0, 9 - candles_lit)])
                 else:
                     buffer = bytes([max(0, self.match - candles_lit)])
                 ctx.process_handle.write_bytes(slot_address + 0x1B2, buffer, 1)

--- a/worlds/animal_well/client.py
+++ b/worlds/animal_well/client.py
@@ -915,6 +915,12 @@ class AWItems:
                 buffer = int(bits, 2).to_bytes((len(bits) + 7) // 8, byteorder="little")
                 ctx.process_handle.write_bytes(slot_address + 0x1DC, buffer, 2)
 
+                # select firecrackers if firecrackers is unlocked and no other equipment is selected,
+                # since picking up other equipment before firecrackers doesn't set the selected equipment,
+                # and firecrackers is given by default anyway
+                if ctx.process_handle.read_bytes(slot_address + 0x1EA, 1)[0] == 0 and self.firecrackers:
+                    ctx.process_handle.write_bytes(slot_address + 0x1EA, b"\x01", 1)
+
                 # Read Other Items
                 flags = int.from_bytes(ctx.process_handle.read_bytes(slot_address + 0x1DE, 1), byteorder="little")
                 possess_m_disc = self.m_disc and (bool(flags >> 0 & 1) or ctx.first_m_disc)


### PR DESCRIPTION
## What is this fixing or adding?

- Patches mock disc chest appearing closed if mock disc wasn't received yet by jmping over the part of the chest loader that specifically checks for the mock disc ownership and quest flags (only checks chests bit 27 now)
- Patches out firecracker dialog popup on first firecracker pickup like the dozen other dialog patches
- Sets firecrackers as selected equipment by default, because firecrackers are given at start, so you can use the next equipment button without opening the inventory
- Patches out firecrackers being set as selected equipment by the game, in case you've switched to another one already
- If you have matchbox, sets amount of matches to the actual amount of candles unlit for a quick and easy way to check how many you have left
- If you have keyring, sets amount of keys to the actual amount of doors unopened for a quick and easy way to check how many you have left

## How was this tested?

- Picking up firecrackers doesn't seem to open a dialog any more
- Opening the mock disc chest and re-entering the room now keeps the chest open
- Got matchbox and keyring, activated every candle and door and made sure I didn't run ouf of matches or keys