### PR TITLE
Disable k.shard sack spawns, tracker optimization

### DIFF
--- a/worlds/animal_well/bean_patcher.py
+++ b/worlds/animal_well/bean_patcher.py
@@ -805,8 +805,10 @@ class BeanPatcher:
         disable_firecracker_get_dialog_patch = Patch("disable_firecracker_get_dialog", 0x14002cb59, self.process).nop(5)
         disable_firecracker_selected_equipment_patch = Patch("disable_firecracker_selected_equipment", 0x14002caea, self.process).nop(5)
         disable_mockdisc_flags_check_patch = Patch("disable_mockdisc_flags_check", 0x1400c1003, self.process).add_bytes(bytearray([0xEB]))
+        disable_sack_spawn_patch = Patch("disable_sack_spawn_patch", 0x140074710, self.process).add_bytes(bytearray([0xc3]))
+
         if self.log_debug_info:
-            self.log_info(f"Applying disable_chest_item_patch patch...\n{disable_chest_item_patch}")
+            self.log_info(f"Applying disable_chest_item_patch patch...")
         if disable_chest_item_patch.apply():
             self.revertable_patches.append(disable_chest_item_patch)
         if self.log_debug_info:
@@ -849,6 +851,8 @@ class BeanPatcher:
             self.revertable_patches.append(disable_firecracker_selected_equipment_patch)
         if disable_mockdisc_flags_check_patch.apply():
             self.revertable_patches.append(disable_mockdisc_flags_check_patch)
+        if disable_sack_spawn_patch.apply():
+            self.revertable_patches.append(disable_sack_spawn_patch)
 
     def apply_receive_item_patch(self):
         """

--- a/worlds/animal_well/locations.py
+++ b/worlds/animal_well/locations.py
@@ -165,7 +165,7 @@ location_table: Dict[str, AWLocationData] = {
     lname.bunny_dream.value: AWLocationData(115, ByteSect.bunnies, 28, ["Bunnies"], AWTracker(0, 1, 297, 335)),
     lname.bunny_file_bud.value: AWLocationData(116, ByteSect.bunnies, 10, ["Bunnies"], AWTracker(0, 1, 241, 287)),
     lname.bunny_lava.value: AWLocationData(117, ByteSect.bunnies, 30, ["Bunnies"], AWTracker(0, 1, 279, 146)),
-    lname.bunny_tv.value: AWLocationData(118, ByteSect.bunnies, 8, ["Bunnies"], AWTracker(485, 1, -4, -2)),
+    lname.bunny_tv.value: AWLocationData(118, ByteSect.bunnies, 8, ["Bunnies"], AWTracker(482, 1, 1, 0)),
     lname.bunny_barcode.value: AWLocationData(119, ByteSect.bunnies, 2, ["Bunnies"], AWTracker(0, 1, 269, 147)),
     lname.bunny_ghost_dog.value: AWLocationData(120, ByteSect.bunnies, 25, ["Bunnies"], AWTracker(798, 1, 2, 4)),
     lname.bunny_disc_spike.value: AWLocationData(121, ByteSect.bunnies, 3, ["Bunnies"], AWTracker(0, 1, 83, 87)),


### PR DESCRIPTION
## What is this fixing or adding?

- Disables kangaroo dropping sacks function cause sacks aren't in logic and just act weird
- Optimized extremely slow tracker tile lookup on connect
- Added support for BG layer and tile params for future AWTracker shenanigans

## How was this tested?

- Go to the first kangaroo spot and spook the kangaroo with firecrackers, no sack.
- Tracker still seems to work and doesn't take forever to init