### PR TITLE
Add flute jumps to logic as obscure tricks

### DIFF
--- a/worlds/animal_well/names.py
+++ b/worlds/animal_well/names.py
@@ -41,6 +41,7 @@ class RegionNames(str, Enum):
     bear_chameleon_room_1 = "Bear Chameleon Room 1"  # first chameleon encounter with the chinchilla
     bear_ladder_after_chameleon = "Bear Ladder after Chameleon 1"
     bear_slink_room = "Bear Slink Room"  # the room you get slink
+    bear_slink_room_doors = "Bear Slink Room after opening doors"
     bear_transcendental = "Bear Transcendental Egg Room"
     bear_kangaroo_waterfall = "Bear Kangaroo Waterfall and adjacent rooms"  # up left from entry point, need slink
     bear_middle_phone_room = "Bear Middle Phone Room"  # after the previous region, has the fast travel, monkey room

--- a/worlds/animal_well/region_data.py
+++ b/worlds/animal_well/region_data.py
@@ -267,8 +267,6 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
             AWData(AWType.region, [[iname.bubble, iname.remote, iname.can_break_spikes],
                                    [iname.bubble, iname.remote, iname.tanking_damage],
                                    [iname.remote, iname.wheel_hop],
-                                   # flute jump down from the galaxy egg entrance, and disc across (hop or toggle remote)
-                                   [iname.disc, iname.remote, iname.flute, iname.obscure_tricks],
                                    # throwing disc to hit switch while wheel stalling is very tight
                                    [iname.disc, iname.wheel_hop, iname.precise_tricks],
                                    [iname.bubble, iname.disc]]),

--- a/worlds/animal_well/region_data.py
+++ b/worlds/animal_well/region_data.py
@@ -472,16 +472,14 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
     rname.bear_slink_room: {
         lname.slink_chest:
             AWData(AWType.location),
-        rname.bear_transcendental:  # descend, jump into left wall, or disc hop from the platforms underneath
-            AWData(AWType.region, [[iname.slink, iname.bubble], [iname.top, iname.bubble],
-                                   [iname.slink, iname.disc_hop], [iname.top, iname.disc_hop],
-                                   [iname.slink, iname.flute, iname.obscure_tricks],
-                                   [iname.top, iname.flute, iname.obscure_tricks],
-                                   [iname.ball_trick_easy, iname.flute, iname.obscure_tricks],
-                                   [iname.disc_hop, iname.ball_trick_easy],
-                                   [iname.bubble, iname.ball_trick_easy]]),
+        rname.bear_slink_room_doors:
+            AWData(AWType.region, [[iname.slink], [iname.top], [iname.ball_trick_easy]]),
         # bear_area_entry:  # unnecessary because it's a sphere 1 area
         #     AWData(AWType.region),
+    },
+    rname.bear_slink_room_doors: {
+        rname.bear_transcendental:  # descend, jump into left wall, or disc hop from the platforms underneath
+            AWData(AWType.region, [[iname.bubble], [iname.disc_hop], [iname.flute, iname.obscure_tricks]]),
     },
     rname.bear_transcendental: {
         lname.egg_transcendental:

--- a/worlds/animal_well/region_data.py
+++ b/worlds/animal_well/region_data.py
@@ -86,7 +86,8 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
             AWData(AWType.region, [[iname.disc], [iname.bubble_short], [iname.ball_trick_easy],
                                    [iname.yoyo], [iname.top, iname.obscure_tricks]]),
         lname.egg_holiday:  # in the wall to the right of the egg room entrance
-            AWData(AWType.location, [[iname.bubble], [iname.disc_hop], [iname.wheel_hard]]),
+            AWData(AWType.location, [[iname.bubble], [iname.disc_hop], [iname.wheel_hard],
+                                     [iname.flute, iname.obscure_tricks]]),
         lname.egg_rain:
             AWData(AWType.location, [[iname.top]]),
     },
@@ -266,6 +267,8 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
             AWData(AWType.region, [[iname.bubble, iname.remote, iname.can_break_spikes],
                                    [iname.bubble, iname.remote, iname.tanking_damage],
                                    [iname.remote, iname.wheel_hop],
+                                   # flute jump down from the galaxy egg entrance, and disc across (hop or toggle remote)
+                                   [iname.disc, iname.remote, iname.flute, iname.obscure_tricks],
                                    # throwing disc to hit switch while wheel stalling is very tight
                                    [iname.disc, iname.wheel_hop, iname.precise_tricks],
                                    [iname.bubble, iname.disc]]),
@@ -472,6 +475,9 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         rname.bear_transcendental:  # descend, jump into left wall, or disc hop from the platforms underneath
             AWData(AWType.region, [[iname.slink, iname.bubble], [iname.top, iname.bubble],
                                    [iname.slink, iname.disc_hop], [iname.top, iname.disc_hop],
+                                   [iname.slink, iname.flute, iname.obscure_tricks],
+                                   [iname.top, iname.flute, iname.obscure_tricks],
+                                   [iname.ball_trick_easy, iname.flute, iname.obscure_tricks],
                                    [iname.disc_hop, iname.ball_trick_easy],
                                    [iname.bubble, iname.ball_trick_easy]]),
         # bear_area_entry:  # unnecessary because it's a sphere 1 area
@@ -566,7 +572,9 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         lname.match_bear:
             AWData(AWType.location),
         rname.chocolate_egg_spot:
-            AWData(AWType.region, [[iname.bubble], [iname.wheel_hard]]),  # wall juts out, need bubble
+            # wall juts out, need bubble or mid-air jump
+            AWData(AWType.region, [[iname.bubble], [iname.wheel_hard],
+                                   [iname.flute, iname.obscure_tricks]]),
         rname.match_center_well_spot:
             AWData(AWType.region),  # wall is flush, just hold left
         rname.bear_truth_egg_spot:
@@ -1218,11 +1226,14 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         lname.egg_pickled:  # hold right while falling down the well
             AWData(AWType.location),
         rname.chocolate_egg_spot:
-            AWData(AWType.region, [[iname.wheel_hard], [iname.bubble]]),  # wall juts out, need bubble
+            # wall juts out, need bubble or mid-air jump
+            AWData(AWType.region, [[iname.wheel_hard], [iname.bubble],
+                                   [iname.flute, iname.obscure_tricks]]),
         rname.match_center_well_spot:
             AWData(AWType.region),  # wall is flush, just hold left
         rname.bear_match_chest_spot:
-            AWData(AWType.region, [[iname.wheel_hard], [iname.bubble]]),
+            AWData(AWType.region, [[iname.wheel_hard], [iname.bubble],
+                                   [iname.flute, iname.obscure_tricks]]),
         rname.bear_truth_egg_spot:
             AWData(AWType.region, [[iname.wheel_hard], [iname.bubble, iname.precise_tricks]]),
     },
@@ -1236,7 +1247,8 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         rname.top_of_the_well:
             AWData(AWType.region, [[iname.bubble_long], [iname.wheel_hard]]),
         rname.bear_truth_egg_spot:
-            AWData(AWType.region, [[iname.wheel_hard], [iname.bubble, iname.precise_tricks]]),
+            AWData(AWType.region, [[iname.wheel_hard], [iname.bubble, iname.precise_tricks],
+                                   [iname.flute, iname.obscure_tricks]]),
     },
     rname.match_center_well_spot: {
         lname.match_center_well:  # across from the chocolate egg


### PR DESCRIPTION
## What is this fixing or adding?

Add flute jumps to logic as obscure tricks. A flute jump involves sliding off the edge of a platform while pulling out the flute, so that in mid-air you can jump out of playing the flute.

1. Holiday Egg (from ledge above)
2. Transcendental Egg (after the Slink chest doors are opened)
3. Chocolate Egg (from Bear match area)
4. Bear Match Area (from higher in the shaft)
5. Truth Egg (from Chocolate Egg)
6. ~~Fish Lower (from Fish Head with the remote but disc is needed)~~

There may be other places where flute jumps are possible, such as getting the B. Wand chest without doing the tutorial seahorse bubble room (which requires no items so we don't bother with adding the flute jump to logic).

## How was this tested?
Generated with obscure tricks on.