### PR TITLE
Switch from using module offsets to AoB patterns

### DIFF
--- a/worlds/animal_well/__init__.py
+++ b/worlds/animal_well/__init__.py
@@ -76,7 +76,7 @@ class AnimalWellWorld(World):
     """
     game = "ANIMAL WELL"
     web = AnimalWellWeb()
-    version_string: str = "v0.4.3 - dev"
+    version_string: str = "v0.4.4 - dev"
 
     options: AnimalWellOptions
     options_dataclass = AnimalWellOptions

--- a/worlds/animal_well/bean_patcher.py
+++ b/worlds/animal_well/bean_patcher.py
@@ -1153,7 +1153,7 @@ class BeanPatcher:
             self.custom_memory_current_offset += 256
             self.tracker_draw_routine_addr = self.custom_memory_current_offset
 
-        tracker_draw_injection_address = self.module_base + 0x40F55 # was 0x40d21
+        tracker_draw_injection_address = self.module_base + 0x40FB1 # was 0x40d21
         tracker_draw_trampoline = (Patch("tracker_draw_trampoline", tracker_draw_injection_address, self.process)
                                      .mov_to_rax(self.tracker_draw_routine_addr).jmp_rax().nop(3))
 

--- a/worlds/animal_well/bean_patcher.py
+++ b/worlds/animal_well/bean_patcher.py
@@ -1127,7 +1127,7 @@ class BeanPatcher:
         stamp type in our custom stamps, used to index the color array to set the color and
         then removed before handing the stamp type back to the game.
         """
-        injection_address = self.find_pattern("8d 14 2b 83 c2 04 44 89 f1 41 b8 01 00 00 00 e8 ?? ?? ?? ??", True) # was 0x42ce8, 42F78
+        injection_address = self.find_pattern("0f b6 c9 c1 e1 18 09 c1", True) # was 0x42ce8, 42F78
         if not self.tracker_initialized:
             self.tracker_icons_addr = self.custom_memory_current_offset
             tracker_icons_patch = (
@@ -1161,7 +1161,7 @@ class BeanPatcher:
                 .add_bytes(bytearray([0x58, 0x41, 0x5D, 0x41, 0x5E, 0x41, 0x5F]))
                 .add_bytes(bytearray([0x49, 0xBE]))
                 .add_bytes((self.tracker_icons_addr+16).to_bytes(8, "little"))
-                .jmp_far(self.find_pattern("41 0f b7 14 46 66 44 0f 7e c9 66 0f 7e f0 48 c1 e0 20 48 09 c1 c6 44 24 28 00 c6 44 24 20 00")) # was 0x42b20, 42DB0
+                .jmp_far(self.find_pattern("f3 0f 10 3d ?? ?? ?? ?? f3 44 0f 10 05 ?? ?? ?? ?? f3 44 0f 10 15 ?? ?? ?? ?? 4c 8d 35 ?? ?? ?? ?? 31 ed eb 54", True)) # was 0x42b20, 42DB0
                 )
             self.custom_memory_current_offset += len(tracker_color_patch)
             tracker_icons_patch.apply()

--- a/worlds/animal_well/bean_patcher.py
+++ b/worlds/animal_well/bean_patcher.py
@@ -865,7 +865,7 @@ class BeanPatcher:
             .pop_r9().pop_r8().pop_rdx().pop_rcx()
             .mov_rdx(self.application_state_address)
             .cmp_ebx(0xe10)
-            .jl_far(self.find_pattern("4c 8d 82 00 04 00 00 48 81 c2 70 36 09 00 b9 02 00 00 00 e8 e7 41 fe ff")) # was 0x140044391 0x140044621
+            .jl_far(self.find_pattern("4c 8d 82 00 04 00 00 48 81 c2 ?? ?? ?? ?? b9 02 00 00 00 e8 ?? ?? ?? ?? e8 ?? ?? ?? ?? 0f 28 b4 24 70 02 00 00")) # was 0x140044391 0x140044621
             .jmp_far(self.find_pattern("8b 82 44 36 09 00 89 82 40 36 09 00 c7 82 10 36 09 00 00 00 00 00 c7 82"
                                        " 18 36 09 00 00 00 00 00 c7 82 44 36 09 00 09 00 00 00 c7 82 48 36 09 00 00 00 00 00")) # was 0x14004435b 0x1400445eb
             .nop(0x10))

--- a/worlds/animal_well/bean_patcher.py
+++ b/worlds/animal_well/bean_patcher.py
@@ -729,10 +729,10 @@ class BeanPatcher:
         self.process.write_bytes(self.module_base + 0x2D9AF00, self.custom_memory_current_offset.to_bytes(8, "little", signed=False), 8) # was 2D93F00
         self.custom_memory_current_offset += len(warp_to_hub_text)
         pause_menu_increase_option_count_1_patch = (
-            Patch("pause_menu_increase_option_count_1_patch", self.module_base + 0x43F85, self.process) # was 0x43cf7
+            Patch("pause_menu_increase_option_count_1_patch", self.module_base + 0x43F87, self.process) # was 0x43cf7
             .add_bytes(b"\x02"))
         pause_menu_increase_option_count_2_patch = (
-            Patch("pause_menu_increase_option_count_2_patch", self.module_base + 0x442DF, self.process) # was 44052
+            Patch("pause_menu_increase_option_count_2_patch", self.module_base + 0x442E2, self.process) # was 44052
             .add_bytes(b"\x03"))
         pause_menu_on_confirm_patch = (
             Patch("pause_menu_on_confirm_patch", self.custom_memory_current_offset, self.process)

--- a/worlds/animal_well/bean_patcher.py
+++ b/worlds/animal_well/bean_patcher.py
@@ -458,6 +458,14 @@ class BeanPatcher:
 
         return self.tracker_stamps_addr
 
+    @property
+    def base_layer_address(self):
+        if not self.attached_to_process:
+            self.log_error("Can't get base layer address without being attached to a process.")
+            return None
+
+        return self.module_base + 0x2BDFE20
+
     def attach_to_process(self, process=None) -> bool:
         if process is not None:
             self.process = process

--- a/worlds/animal_well/bean_patcher.py
+++ b/worlds/animal_well/bean_patcher.py
@@ -726,7 +726,7 @@ class BeanPatcher:
             .nop(0xd))
         warp_to_hub_text = "warp to hub".encode("utf-16le") + b"\x00\x00"
         self.process.write_bytes(self.custom_memory_current_offset, warp_to_hub_text, len(warp_to_hub_text))
-        self.process.write_bytes(self.module_base + 0x2D9AF00, self.custom_memory_current_offset.to_bytes(8, "little", signed=False), 8) # was 2D93F00
+        self.process.write_bytes(self.module_base + 0x2D9AF20, self.custom_memory_current_offset.to_bytes(8, "little", signed=False), 8) # was 2D93F00
         self.custom_memory_current_offset += len(warp_to_hub_text)
         pause_menu_increase_option_count_1_patch = (
             Patch("pause_menu_increase_option_count_1_patch", self.module_base + 0x43F87, self.process) # was 0x43cf7

--- a/worlds/animal_well/bean_patcher.py
+++ b/worlds/animal_well/bean_patcher.py
@@ -1114,7 +1114,8 @@ class BeanPatcher:
         if not self.tracker_initialized:
             self.tracker_stamps_addr = self.custom_memory_current_offset
             self.custom_memory_current_offset += CUSTOM_STAMPS * 6
-        redirect_stamps_address = self.find_pattern("0f 84 0e 02 00 00 49 8d bd 2c 02 00 00 f3 0f 10 3d ?? ?? ?? ??") # was 0x42AEE, 42D7E
+        redirect_stamps_address = self.find_pattern("e8 ?? ?? ?? ?? 41 8a 85 25 02 00 00 84 c0 4c 89 f6", True) # was 0x42AEE, 42D7E
+        # redirect_stamps_address = self.find_pattern("0f 84 0e 02 00 00 49 8d bd 2c 02 00 00 f3 0f 10 3d ?? ?? ?? ??") # was 0x42AEE, 42D7E
         redirect_stamps_patch = Patch(
             "redirect_stamps", redirect_stamps_address, self.process).mov_rdi(self.tracker_stamps_addr+4).nop(3)
         if self.log_debug_info and not self.tracker_initialized:
@@ -1128,7 +1129,7 @@ class BeanPatcher:
         stamp type in our custom stamps, used to index the color array to set the color and
         then removed before handing the stamp type back to the game.
         """
-        injection_address = self.find_pattern("0f 57 ff f3 41 0f 2a fe f3 41 0f 10 44 24 14 f3 0f 58 f0 0f 28 cf") # was 0x42ce8, 42F78
+        injection_address = self.find_pattern("8d 14 2b 83 c2 04 44 89 f1 41 b8 01 00 00 00 e8 ?? ?? ?? ??", True) # was 0x42ce8, 42F78
         if not self.tracker_initialized:
             self.tracker_icons_addr = self.custom_memory_current_offset
             tracker_icons_patch = (
@@ -1205,7 +1206,7 @@ class BeanPatcher:
             self.custom_memory_current_offset += 256
             self.tracker_draw_routine_addr = self.custom_memory_current_offset
 
-        tracker_draw_injection_address = self.find_pattern("e8 ?? ?? ?? ?? b9 29 00 00 00 e8 ?? ?? ?? ?? b9 f4 c0 64 ff e8 ?? ?? ?? ??")# was 0x40d21, 40FB1
+        tracker_draw_injection_address = self.find_pattern("f3 41 0f 11 4c 24 20 b9 82 6e 5a 64", True) # was 0x40d21, 40FB1
         tracker_draw_trampoline = (Patch("tracker_draw_trampoline", tracker_draw_injection_address, self.process)
                                      .mov_to_rax(self.tracker_draw_routine_addr).jmp_rax().nop(3))
 

--- a/worlds/animal_well/bean_patcher.py
+++ b/worlds/animal_well/bean_patcher.py
@@ -1286,7 +1286,7 @@ class BeanPatcher:
             self.change_save_file_name(seeded_save_file)
             self.process.write_uchar(self.application_state_address + 0x400 + 0x750cc, 1)  # return to title screen to reload new save file
             self.process.write_uchar(self.application_state_address + 0x40C, 0)  # set current save slot to 0
-            self.process.write_uchar(self.module_base + 0x1F3A8, 1)  # was 0x1F17E # disable load game menu
+            self.process.write_uchar(self.module_base + 0x1F3AE, 1)  # was 0x1F17E # disable load game menu
             self.save_file = seeded_save_file
             return True
         return False

--- a/worlds/animal_well/bean_patcher.py
+++ b/worlds/animal_well/bean_patcher.py
@@ -850,10 +850,10 @@ class BeanPatcher:
         self.process.write_bytes(self.text_lookup_table_address + 0x20, self.custom_memory_current_offset.to_bytes(8, "little", signed=False), 8) # was 2D93F00 # then 0x142D9AF20
         self.custom_memory_current_offset += len(warp_to_hub_text)
         pause_menu_increase_option_count_1_patch = (
-            Patch("pause_menu_increase_option_count_1_patch", self.find_pattern("8b b0 10 36 09 00 83 fe 01 7f 3f") + 8, self.process) # was 0x43cf7 43f87
+            Patch("pause_menu_increase_option_count_1_patch", self.find_pattern("83 fe 01 7f 3f 83 c6 01") + 3, self.process) # was 0x43cf7 43f87
             .add_bytes(b"\x02"))
         pause_menu_increase_option_count_2_patch = (
-            Patch("pause_menu_increase_option_count_2_patch", self.find_pattern("e8 51 9e 02 00 48 83 fe 02 74 11") + 8, self.process) # was 44052 442e2
+            Patch("pause_menu_increase_option_count_2_patch", self.find_pattern("48 83 fe 02 74 11 44 8b 64 f4 58") + 3, self.process) # was 44052 442e2
             .add_bytes(b"\x03"))
         pause_menu_on_confirm_patch = (
             Patch("pause_menu_on_confirm_patch", self.custom_memory_current_offset, self.process)

--- a/worlds/animal_well/bean_patcher.py
+++ b/worlds/animal_well/bean_patcher.py
@@ -637,7 +637,7 @@ class BeanPatcher:
 
         # self.apply_receive_item_patch()
 
-        # self.apply_skip_credits_patch()
+        self.apply_skip_credits_patch()
 
         # self.apply_deathlink_patch()
 
@@ -1155,7 +1155,7 @@ class BeanPatcher:
         Disables the credits by NOPing out a check that checks if the credits timer is still running,
         effectively jumping to the end of the credits instantly when they start rolling.
         """
-        skip_credits_address = self.module_base + 0x47969 # was 0x476D9
+        skip_credits_address = self.find_pattern("73 4c c7 85 c0 34 03 00 00 00 00 00 8b 85 c4 34 03 00 83 c0 01") # was 0x476D9, 0x140047969
         skip_credits_patch = Patch(
             "skip_credits", skip_credits_address, self.process).nop(2)
         if self.log_debug_info:
@@ -1320,7 +1320,7 @@ class BeanPatcher:
         0x14003BA8F 49 89 F8                                mov     r8, rdi                   ; save
         0x14003BA92 E8 59 A8 02 00                          call    updatePlayerState
         """
-        bean_died_address = self.module_base + 0x3BCCA # was 0x3BA8A
+        bean_died_address = self.find_pattern("48 89 f1 b2 05 49 89 f8")  # was 0x3BA8A, 0x14003BCCA
 
         self.bean_has_died_address = self.custom_memory_current_offset
 
@@ -1341,7 +1341,7 @@ class BeanPatcher:
                              .mov_rbx(self.bean_has_died_address)
                              .mov_al_to_address_in_rbx()
                              .update_player_state(self.player_address, 5, self.current_save_address)
-                             .jmp_far(self.module_base + 0x3BCD7) # was 0x3BA97
+                             .jmp_far(self.find_pattern("c6 86 90 00 00 00 00 80 a6 55 89 00 00 fb 8a 46 5d 3c 07"))  # was 0x3BA97, 0x14003BCD7
                              )
 
         self.custom_memory_current_offset += len(bean_died_routine)
@@ -1511,8 +1511,6 @@ class BeanPatcher:
                 self.process.write_bool(self.bean_has_died_address, False)
                 if self.on_bean_death_function is not None:
                     await self.on_bean_death_function()
-
-        self.enable_room_palette_override(random.randrange(0, 31))
 
     def key_pressed(self, key):
         if self.cmd_keys is None or self.cmd_keys_old is None:

--- a/worlds/animal_well/bean_patcher.py
+++ b/worlds/animal_well/bean_patcher.py
@@ -815,11 +815,12 @@ class BeanPatcher:
         When selected, this option warps the bean back to the flame statue room.
         Useful for getting out of potential softlocks.
         """
+        string_id_to_replace = 4
         pause_menu_patch_update_option_text = (
             Patch("pause_menu_patch_update_option_text", self.custom_memory_current_offset, self.process)
             .mov_to_rsp_offset(0x50, 1)
             .mov_to_rsp_offset(0x58, 5)
-            .mov_to_rsp_offset(0x60, 4)  # 0x4 is "Pre-Alpha", we'll update it with our new text
+            .mov_to_rsp_offset(0x60, string_id_to_replace)  # 0x4 is "Pre-Alpha", we'll update it with our new text
             # 0x69 -> blocked, 0x72 -> wake up, 0x73 -> locked, 0xae -> beacon, 0xb2 -> travel
             .mov_to_rax(0xc)
             .mov_rax_to_rsp_offset(0x68)
@@ -843,9 +844,24 @@ class BeanPatcher:
             .nop(0xd))
         warp_to_hub_text = "warp to hub".encode("utf-16le") + b"\x00\x00"
         self.process.write_bytes(self.custom_memory_current_offset, warp_to_hub_text, len(warp_to_hub_text))
-        self.log_info(f"text_lookup_table_address: {hex(self.text_lookup_table_address)}, text_lookup_table_address + 0x20: {hex(self.text_lookup_table_address + 0x20)}")
+        self.log_info(f"text_lookup_table_address: {hex(self.text_lookup_table_address)}, text_lookup_table_address + ({hex(string_id_to_replace)} * 8): "
+                      f"{hex(self.text_lookup_table_address + (string_id_to_replace * 8))}")
         self.log_info(f"location of new 'warp to hub' text: {hex(self.custom_memory_current_offset)}")
-        self.process.write_bytes(self.text_lookup_table_address + 0x20, self.custom_memory_current_offset.to_bytes(8, "little", signed=False), 8) # was 2D93F00 # then 0x142D9AF20
+        warp_to_hub_text_address_bytes = self.custom_memory_current_offset.to_bytes(8, "little", signed=False)
+        string_count_per_language = 0x124
+
+        self.process.write_bytes(self.text_lookup_table_address + (string_id_to_replace + (string_count_per_language * 0)) * 8, warp_to_hub_text_address_bytes, 8) #2D93F00, 2D9AF20
+        self.process.write_bytes(self.text_lookup_table_address + (string_id_to_replace + (string_count_per_language * 1)) * 8, warp_to_hub_text_address_bytes, 8)
+        self.process.write_bytes(self.text_lookup_table_address + (string_id_to_replace + (string_count_per_language * 2)) * 8, warp_to_hub_text_address_bytes, 8)
+        self.process.write_bytes(self.text_lookup_table_address + (string_id_to_replace + (string_count_per_language * 3)) * 8, warp_to_hub_text_address_bytes, 8)
+        self.process.write_bytes(self.text_lookup_table_address + (string_id_to_replace + (string_count_per_language * 4)) * 8, warp_to_hub_text_address_bytes, 8)
+        self.process.write_bytes(self.text_lookup_table_address + (string_id_to_replace + (string_count_per_language * 5)) * 8, warp_to_hub_text_address_bytes, 8)
+        self.process.write_bytes(self.text_lookup_table_address + (string_id_to_replace + (string_count_per_language * 6)) * 8, warp_to_hub_text_address_bytes, 8)
+        self.process.write_bytes(self.text_lookup_table_address + (string_id_to_replace + (string_count_per_language * 7)) * 8, warp_to_hub_text_address_bytes, 8)
+        self.process.write_bytes(self.text_lookup_table_address + (string_id_to_replace + (string_count_per_language * 8)) * 8, warp_to_hub_text_address_bytes, 8)
+        self.process.write_bytes(self.text_lookup_table_address + (string_id_to_replace + (string_count_per_language * 9)) * 8, warp_to_hub_text_address_bytes, 8)
+        self.process.write_bytes(self.text_lookup_table_address + (string_id_to_replace + (string_count_per_language * 10)) * 8, warp_to_hub_text_address_bytes, 8)
+
         self.custom_memory_current_offset += len(warp_to_hub_text)
         pause_menu_increase_option_count_1_patch = (
             Patch("pause_menu_increase_option_count_1_patch", self.find_pattern("83 fe 01 7f 3f 83 c6 01") + 2, self.process) # was 0x43cf7 43f87

--- a/worlds/animal_well/bean_patcher.py
+++ b/worlds/animal_well/bean_patcher.py
@@ -214,58 +214,78 @@ class Patch(Patch):
 
 # region FunctionOffsets
 # Accurate as of AW file version 1.0.0.18
-draw_small_text: int = 0x14006E3F0
-draw_big_text: int = 0x14006DE30
-draw_symbol: int = 0x14006A6C0
-draw_sprite: int = 0x14001AEC0
-get_sprite: int = 0x140063CA0
-push_shader_to_stack: int = 0x140017840
-pop_shader_from_stack: int = 0x1400178A0
-push_color_to_stack: int = 0x1400177D0
-pop_color_from_stack: int = 0x140017830
-pop_from_position_stack: int = 0x140017920
-set_tall_text_mode: int = 0x14006DC00
-set_current_color: int = 0x1400177B0
-set_current_shader: int = 0x14001A280
+# draw_small_text: int = 0x14006E3F0
+# draw_big_text: int = 0x14006DE30
+# draw_symbol: int = 0x14006A6C0
+# draw_sprite: int = 0x14001AEC0
+# get_sprite: int = 0x140063CA0
+# push_shader_to_stack: int = 0x140017840
+# pop_shader_from_stack: int = 0x1400178A0
+# push_color_to_stack: int = 0x1400177D0
+# pop_color_from_stack: int = 0x140017830
+# pop_from_position_stack: int = 0x140017920
+# set_tall_text_mode: int = 0x14006DC00
+# set_current_color: int = 0x1400177B0
+# set_current_shader: int = 0x14001A280
+# get_key_pressed: int = 0x140011C70
+# get_gamepad_button_pressed: int = 0x140011EA0
+# get_an_item: int = 0x1400C15C0
+# warp: int = 0x140074DD0
+# update_player_state: int = 0x1400662F0
+
+# Accurate as of AW file version 1.0.0.20
+draw_small_text: int = 0x14006E6F0
+draw_big_text: int = 0x14006E130
+draw_symbol: int = 0x14006A9B0 # jumps to 0x14001A1C0
+draw_sprite: int = 0x14001B0F0
+get_sprite: int = 0x140063FA0 # jumps to 0x14001A850
+push_shader_to_stack: int = 0x140017A70
+pop_shader_from_stack: int = 0x140017AD0
+push_color_to_stack: int = 0x140017A00
+pop_color_from_stack: int = 0x140017A60
+pop_from_position_stack: int = 0x140017B50
+set_tall_text_mode: int = 0x14006DF00
+set_current_color: int = 0x1400179E0
+set_current_shader: int = 0x14001A4B0
 get_key_pressed: int = 0x140011C70
 get_gamepad_button_pressed: int = 0x140011EA0
-get_an_item: int = 0x1400C15C0
-warp: int = 0x140074DD0
-update_player_state: int = 0x1400662F0
+get_an_item: int = 0x1400C1870
+warp: int = 0x140075080
+update_player_state: int = 0x1400665F0
 # endregion
 
 # region OtherOffsets
 STEP_AND_TIME_DISPLAY_ORIGINAL_VALUES = {
-    0x504fb: 2.0,
-    0x504ff: 2.0,
-    0x5053e: 6,
-    0x50543: 6,
-    0x5055a: 7,
-    0x5055f: 5,
-    0x50417: 310.0,
-    0x5041b: 3.0,
-    0x5044f: 280,
-    0x50454: 5,
-    0x50481: 278,
-    0x50486: 6,
-    0x504b3: 279,
-    0x504b8: 5
+    0x507A9 + 2: 2.0, # was 0x504fb
+    0x507A9 + 6: 2.0, # was 0x504ff
+    0x507ED + 1: 6, # was 0x5053e
+    0x507F2 + 1: 6, # was 0x50543
+    0x50809 + 1: 7, # was 0x5055a
+    0x5080E + 1: 5, # was 0x5055f
+    0x506C5 + 2: 310.0, # was 0x50417
+    0x506C5 + 6: 3.0, # was 0x5041b
+    0x506FE + 1: 280, # was 0x5044f
+    0x50703 + 1: 5, # was 0x50454
+    0x50730 + 1: 278, # was 0x50481
+    0x50735 + 1: 6, # was 0x50486
+    0x50762 + 1: 279, # was 0x504b3
+    0x50767 + 1: 5 # was 0x504b8
 }
 STEP_AND_TIME_DISPLAY_UPDATED_VALUES = {
-    0x504fb: 2.0,
-    0x504ff: 2.0 + 5,
-    0x5053e: 6,
-    0x50543: 6 + 5,
-    0x5055a: 7,
-    0x5055f: 5 + 5,
-    0x50417: 310.0,
-    0x5041b: 3.0 + 5,
-    0x5044f: 280,
-    0x50454: 5 + 5,
-    0x50481: 278,
-    0x50486: 6 + 5,
-    0x504b3: 279,
-    0x504b8: 5 + 5
+    0x507A9 + 2: 2.0, # was 0x504fb
+    0x507A9 + 6: 2.0 + 5, # was 0x504ff
+    0x507ED + 1: 6, # was 0x5053e
+    0x507F2 + 1: 6 + 5, # was 0x50543
+    0x50809 + 1: 7, # was 0x5055a
+    0x5080E + 1: 5 + 5, # was 0x5055f
+    0x506C5 + 2: 310.0, # was 0x50417
+    0x506C5 + 6: 3.0 + 5, # was 0x5041b
+    0x506FE + 1: 280, # was 0x5044f
+    0x50703 + 1: 5 + 5, # was 0x50454
+    0x50730 + 1: 278, # was 0x50481
+    0x50735 + 1: 6 + 5, # was 0x50486
+    0x50762 + 1: 279, # was 0x504b3
+    0x50767 + 1: 5 + 5 # was 0x504b8
 }
 # endregion
 
@@ -461,7 +481,7 @@ class BeanPatcher:
 
         self.module_base = self.aw_module.lpBaseOfDll
 
-        application_state_pointer_address = self.module_base + 0x02BD5308
+        application_state_pointer_address = self.module_base + 0x2D255F8 # was 2BD5308
         if self.log_debug_info:
             self.log_info(f"Attempting to find start address via pointer at {hex(application_state_pointer_address)}")
 
@@ -565,7 +585,7 @@ class BeanPatcher:
         """
             This patch displays the text "AP Randomizer" on the title screen.
         """
-        main_menu_draw_injection_address = self.module_base + 0x1f025
+        main_menu_draw_injection_address = self.module_base + 0x1F255 # 0x1f025
         self.main_menu_draw_string_addr = self.custom_memory_current_offset
         self.custom_memory_current_offset += TITLE_SCREEN_MAX_TEXT_LENGTH
         main_menu_draw_routine_address = self.custom_memory_current_offset
@@ -606,7 +626,7 @@ class BeanPatcher:
         It additionally pushes the steps and time counters lower on the screen to make room for the new text display.
         This patch can also be extended in the future to display other things in-game.
         """
-        game_draw_injection_address = self.module_base + 0x5068b
+        game_draw_injection_address = self.module_base + 0x5093B #0x5068b
         self.game_draw_routine_string_addr = self.custom_memory_current_offset
         self.custom_memory_current_offset += self.game_draw_routine_string_size + 0x10
 
@@ -686,7 +706,7 @@ class BeanPatcher:
             # 0x69 -> blocked, 0x72 -> wake up, 0x73 -> locked, 0xae -> beacon, 0xb2 -> travel
             .mov_to_rax(0xc)
             .mov_rax_to_rsp_offset(0x68)
-            .jmp_far(0x140043cdf)  # 84 -> control panel
+            .jmp_far(self.module_base + 0x43F6F)  # 84 -> control panel)  # was 0x140043cdf
             .nop(0x10))
         self.custom_memory_current_offset += len(pause_menu_patch_update_option_text)
         pause_menu_resume_and_warp_patch = (
@@ -697,26 +717,26 @@ class BeanPatcher:
             .warp(self.player_address, self.unstuck_room_x, self.unstuck_room_y, self.unstuck_pos_x, self.unstuck_pos_y, self.unstuck_map)
             .pop_r9().pop_r8().pop_rdx().pop_rcx()
             .mov_to_rax(self.application_state_address)
-            .jmp_far(0x140044223)
+            .jmp_far(self.module_base + 0x444B3) # was 0x44223
             .nop(0x10))
         self.custom_memory_current_offset += len(pause_menu_resume_and_warp_patch)
         pause_menu_patch_update_option_text_trampoline = (
-            Patch("pause_menu_patch_update_option_text_trampoline", 0x140043cc4, self.process)
+            Patch("pause_menu_patch_update_option_text_trampoline", self.module_base + 0x43F54, self.process) # was 43CC4
             .jmp_far(pause_menu_patch_update_option_text.base_address)
             .nop(0xd))
         warp_to_hub_text = "warp to hub".encode("utf-16le") + b"\x00\x00"
         self.process.write_bytes(self.custom_memory_current_offset, warp_to_hub_text, len(warp_to_hub_text))
-        self.process.write_bytes(0x142D93F00, self.custom_memory_current_offset.to_bytes(8, "little", signed=False), 8)
+        self.process.write_bytes(self.module_base + 0x2D9AF00, self.custom_memory_current_offset.to_bytes(8, "little", signed=False), 8) # was 2D93F00
         self.custom_memory_current_offset += len(warp_to_hub_text)
         pause_menu_increase_option_count_1_patch = (
-            Patch("pause_menu_increase_option_count_1_patch", 0x140043cf7, self.process)
+            Patch("pause_menu_increase_option_count_1_patch", self.module_base + 0x43F85, self.process) # was 0x43cf7
             .add_bytes(b"\x02"))
         pause_menu_increase_option_count_2_patch = (
-            Patch("pause_menu_increase_option_count_2_patch", 0x140044052, self.process)
+            Patch("pause_menu_increase_option_count_2_patch", self.module_base + 0x442DF, self.process) # was 44052
             .add_bytes(b"\x03"))
         pause_menu_on_confirm_patch = (
             Patch("pause_menu_on_confirm_patch", self.custom_memory_current_offset, self.process)
-            .call_far(0x14006ec30)
+            .call_far(self.module_base + 0x6EF30) # was 0x6ec30
             .push_rcx().push_rdx().push_r8().push_r9()
             .mov_from_absolute_address_to_eax(self.application_state_address + 0x93610)
             .cmp_eax(2)
@@ -724,12 +744,12 @@ class BeanPatcher:
             .pop_r9().pop_r8().pop_rdx().pop_rcx()
             .mov_rdx(self.application_state_address)
             .cmp_ebx(0xe10)
-            .jl_far(0x140044391)
-            .jmp_far(0x14004435b)
+            .jl_far(self.module_base + 0x44621) # was 0x140044391
+            .jmp_far(self.module_base + 0x445EB) # was 0x14004435b
             .nop(0x10))
         self.custom_memory_current_offset += len(pause_menu_on_confirm_patch)
         pause_menu_patch_on_confirm_trampoline_patch = (
-            Patch("pause_menu_patch_on_confirm_trampoline_patch", 0x140044347, self.process)
+            Patch("pause_menu_patch_on_confirm_trampoline_patch", self.module_base + 0x445D7, self.process) # was 0x140044347
             .jmp_far(pause_menu_on_confirm_patch.base_address)
             .nop(6))
         if self.log_debug_info:
@@ -816,16 +836,16 @@ class BeanPatcher:
                               .pop_r9().pop_r8().pop_rdx().pop_rcx()
                               .nop(0x80)
                               .mov_edi(0x841c)
-                              .mov_from_absolute_address_to_rax(0x1420949D0).movq_rax_to_xmm6()
-                              .mov_from_absolute_address_to_rax(0x1420949F4).movq_rax_to_xmm7()
-                              .jmp_far(0x14003B7FD)
+                              .mov_from_absolute_address_to_rax(self.module_base + 0x9A9D0).movq_rax_to_xmm6() # was 0x20949D0
+                              .mov_from_absolute_address_to_rax(self.module_base + 0x9A9F4).movq_rax_to_xmm7() # was 0x20949F4
+                              .jmp_far(self.module_base + 0x3BA3D) # was 0x14003B7FD
                               )
         self.custom_memory_current_offset += len(input_reader_patch)
         if self.log_debug_info:
             self.log_info(f"Applying input_reader_patch...\n{input_reader_patch}")
         if input_reader_patch.apply():
             self.revertable_patches.append(input_reader_patch)
-        input_reader_trampoline = (Patch("input_reader_trampoline", 0x14003B7D1, self.process)
+        input_reader_trampoline = (Patch("input_reader_trampoline", self.module_base + 0x3BA11, self.process) # was 0x14003B7D1
                                    .jmp_far(input_reader_patch.base_address).nop(2))
         if self.log_debug_info:
             self.log_info(f"Applying input_reader_trampoline...\n{input_reader_trampoline}")
@@ -836,8 +856,8 @@ class BeanPatcher:
         """
         Disables the built-in anti-cheat that rolls back changes that occur to the player outside the frame function.
         """
-        frame_anticheat_address = self.module_base + 0x6048A
-        frame_anticheat_complete_address = self.module_base + 0x605B3
+        frame_anticheat_address = self.module_base + 0x6072F # 0x6048A
+        frame_anticheat_complete_address = self.module_base + 0x60863 # 0x605B3
         disable_anticheat_patch = Patch(
             "disable_anti-cheat", frame_anticheat_address, self.process).jmp_far(frame_anticheat_complete_address)
         if self.log_debug_info:
@@ -899,28 +919,28 @@ class BeanPatcher:
         but reducing situations where you might be performing a trick when receiving a piece of equipment from
         another player"s game.
         """
-        disable_chest_item_patch = Patch("disable_chest_item", 0x1400c2871, self.process).xor_r8d_r8d().xor_edx_edx().nop(3)
-        disable_item_get_dialog_patch = Patch("disable_item_get_dialog", 0x1400c2161, self.process).nop(5)
+        disable_chest_item_patch = Patch("disable_chest_item", self.module_base + 0xC2B21, self.process).xor_r8d_r8d().xor_edx_edx().nop(3) # was 0x1400c2871
+        disable_item_get_dialog_patch = Patch("disable_item_get_dialog", self.module_base + 0xC2411, self.process).nop(5) # was 0x1400c2161
         # match, pencil, stethoscope, officeKey, stamps, pedometer, rabbitFig, mockDisc, cake, regularKey, stopwatch, sMedal, eMedal, questionKey
-        disable_egg_get_dialog_patch = Patch("disable_egg_get_dialog", 0x1400c24a3, self.process).nop(5)
-        disable_lantern_get_dialog_patch = Patch("disable_lantern_get_dialog", 0x1400c1c82, self.process).nop(5)
-        disable_flute_get_dialog_patch = Patch("disable_flute_get_dialog", 0x1400c2241, self.process).nop(5)
-        disable_bubble_get_dialog_patch = Patch("disable_bubble_get_dialog", 0x1400c21ea, self.process).nop(5)
-        disable_uv_get_dialog_patch = Patch("disable_uv_get_dialog", 0x1400c1cd9, self.process).nop(5)
-        disable_yoyo_get_dialog_patch = Patch("disable_yoyo_get_dialog", 0x1400c1f21, self.process).nop(5)
-        disable_slink_get_dialog_patch = Patch("disable_slink_get_dialog", 0x1400c1bc0, self.process).nop(5)
-        disable_remote_get_dialog_patch = Patch("disable_remote_get_dialog", 0x1400c211a, self.process).nop(5)
-        disable_wheel_get_dialog_patch = Patch("disable_wheel_get_dialog", 0x1400c22c8, self.process).nop(5)
-        disable_wheel_get_without_saving_cats_dialog_patch = Patch("disable_wheel_get_without_saving_cats_dialog", 0x1400c20b2, self.process).nop(5)
-        disable_ball_get_dialog_patch = Patch("disable_ball_get_dialog", 0x1400c200d, self.process).nop(5)
-        disable_top_get_dialog_patch = Patch("disable_top_get_dialog", 0x1400c1fb6, self.process).nop(5)
-        disable_egg65_get_dialog_patch = Patch("disable_egg65_get_dialog", 0x1400c18be, self.process).nop(5)
-        disable_bbwand_get_dialog_patch = Patch("disable_bbwand_get_dialog", 0x1400c1d75, self.process).nop(5)
-        disable_fannypack_get_dialog_patch = Patch("disable_fannypack_get_dialog", 0x1400c1e81, self.process).nop(5)
-        disable_firecracker_get_dialog_patch = Patch("disable_firecracker_get_dialog", 0x14002cb59, self.process).nop(5)
-        disable_firecracker_selected_equipment_patch = Patch("disable_firecracker_selected_equipment", 0x14002caea, self.process).nop(5)
-        disable_mockdisc_flags_check_patch = Patch("disable_mockdisc_flags_check", 0x1400c1003, self.process).add_bytes(bytearray([0xEB]))
-        disable_sack_spawn_patch = Patch("disable_sack_spawn_patch", 0x140074710, self.process).add_bytes(bytearray([0xc3]))
+        disable_egg_get_dialog_patch = Patch("disable_egg_get_dialog", self.module_base + 0xC2753, self.process).nop(5) # was 0x1400c24a3
+        disable_lantern_get_dialog_patch = Patch("disable_lantern_get_dialog", self.module_base + 0xC1F32, self.process).nop(5) # was 0x1400c1c82
+        disable_flute_get_dialog_patch = Patch("disable_flute_get_dialog", self.module_base + 0xC24F1, self.process).nop(5) # was 0x1400c2241
+        disable_bubble_get_dialog_patch = Patch("disable_bubble_get_dialog", self.module_base + 0xC249A, self.process).nop(5) # was 0x1400c21ea
+        disable_uv_get_dialog_patch = Patch("disable_uv_get_dialog", self.module_base + 0xC1F89, self.process).nop(5) # was 0x1400c1cd9
+        disable_yoyo_get_dialog_patch = Patch("disable_yoyo_get_dialog", self.module_base + 0xC21D1, self.process).nop(5) # was 0x1400c1f21
+        disable_slink_get_dialog_patch = Patch("disable_slink_get_dialog", self.module_base + 0xC1E70, self.process).nop(5) # was 0x1400c1bc0
+        disable_remote_get_dialog_patch = Patch("disable_remote_get_dialog", self.module_base + 0xC23CA, self.process).nop(5) # was 0x1400c211a
+        disable_wheel_get_dialog_patch = Patch("disable_wheel_get_dialog", self.module_base + 0xC2578, self.process).nop(5) # was 0x1400c22c8
+        disable_wheel_get_without_saving_cats_dialog_patch = Patch("disable_wheel_get_without_saving_cats_dialog", self.module_base + 0xC2362, self.process).nop(5) # was 0x1400c20b2
+        disable_ball_get_dialog_patch = Patch("disable_ball_get_dialog", self.module_base + 0xC22BD, self.process).nop(5) # was 0x1400c200d
+        disable_top_get_dialog_patch = Patch("disable_top_get_dialog", self.module_base + 0xC2266, self.process).nop(5) # was 0x1400c1fb6
+        disable_egg65_get_dialog_patch = Patch("disable_egg65_get_dialog", self.module_base + 0xC1B6E, self.process).nop(5) # was 0x1400c18be
+        disable_bbwand_get_dialog_patch = Patch("disable_bbwand_get_dialog", self.module_base + 0xC2025, self.process).nop(5) # was 0x1400c1d75
+        disable_fannypack_get_dialog_patch = Patch("disable_fannypack_get_dialog", self.module_base + 0xC2131, self.process).nop(5) # was 0x1400c1e81
+        disable_firecracker_get_dialog_patch = Patch("disable_firecracker_get_dialog", self.module_base + 0x2CD89, self.process).nop(5) # was 0x14002cb59
+        disable_firecracker_selected_equipment_patch = Patch("disable_firecracker_selected_equipment", self.module_base + 0x2CD1A, self.process).nop(5) # was 0x14002caea
+        disable_mockdisc_flags_check_patch = Patch("disable_mockdisc_flags_check", self.module_base + 0xC12B3, self.process).add_bytes(bytearray([0xEB])) # was 0x1400c1003
+        disable_sack_spawn_patch = Patch("disable_sack_spawn_patch", self.module_base + 0x749C0, self.process).add_bytes(bytearray([0xc3])) # was 0x140074710
 
         if self.log_debug_info:
             self.log_info(f"Applying disable_chest_item_patch patch...")
@@ -1019,7 +1039,7 @@ class BeanPatcher:
         Disables the credits by NOPing out a check that checks if the credits timer is still running,
         effectively jumping to the end of the credits instantly when they start rolling.
         """
-        skip_credits_address = self.module_base + 0x476D9
+        skip_credits_address = self.module_base + 0x47969 # was 0x476D9
         skip_credits_patch = Patch(
             "skip_credits", skip_credits_address, self.process).nop(2)
         if self.log_debug_info:
@@ -1034,7 +1054,7 @@ class BeanPatcher:
         if not self.tracker_initialized:
             self.tracker_stamps_addr = self.custom_memory_current_offset
             self.custom_memory_current_offset += CUSTOM_STAMPS * 6
-        redirect_stamps_address = self.module_base + 0x42AEE
+        redirect_stamps_address = self.module_base + 0x42D7E # was 0x42AEE
         redirect_stamps_patch = Patch(
             "redirect_stamps", redirect_stamps_address, self.process).mov_rdi(self.tracker_stamps_addr+4).nop(3)
         if self.log_debug_info and not self.tracker_initialized:
@@ -1048,7 +1068,7 @@ class BeanPatcher:
         stamp type in our custom stamps, used to index the color array to set the color and
         then removed before handing the stamp type back to the game.
         """
-        injection_address = self.module_base + 0x42ce8
+        injection_address = self.module_base + 0x42F78 # was 0x42ce8
         if not self.tracker_initialized:
             self.tracker_icons_addr = self.custom_memory_current_offset
             tracker_icons_patch = (
@@ -1082,7 +1102,7 @@ class BeanPatcher:
                 .add_bytes(bytearray([0x58, 0x41, 0x5D, 0x41, 0x5E, 0x41, 0x5F]))
                 .add_bytes(bytearray([0x49, 0xBE]))
                 .add_bytes((self.tracker_icons_addr+16).to_bytes(8, "little"))
-                .jmp_far(self.module_base + 0x42b20)
+                .jmp_far(self.module_base + 0x42DB0) # was 0x42b20
                 )
             self.custom_memory_current_offset += len(tracker_color_patch)
             tracker_icons_patch.apply()
@@ -1125,7 +1145,7 @@ class BeanPatcher:
             self.custom_memory_current_offset += 256
             self.tracker_draw_routine_addr = self.custom_memory_current_offset
 
-        tracker_draw_injection_address = self.module_base + 0x40d21
+        tracker_draw_injection_address = self.module_base + 0x40F55 # was 0x40d21
         tracker_draw_trampoline = (Patch("tracker_draw_trampoline", tracker_draw_injection_address, self.process)
                                      .mov_to_rax(self.tracker_draw_routine_addr).jmp_rax().nop(3))
 
@@ -1184,7 +1204,7 @@ class BeanPatcher:
         0x14003BA8F 49 89 F8                                mov     r8, rdi                   ; save
         0x14003BA92 E8 59 A8 02 00                          call    updatePlayerState
         """
-        bean_died_address = self.module_base + 0x3BA8A
+        bean_died_address = self.module_base + 0x3BCCA # was 0x3BA8A
 
         self.bean_has_died_address = self.custom_memory_current_offset
 
@@ -1205,7 +1225,7 @@ class BeanPatcher:
                              .mov_rbx(self.bean_has_died_address)
                              .mov_al_to_address_in_rbx()
                              .update_player_state(self.player_address, 5, self.current_save_address)
-                             .jmp_far(self.module_base + 0x3BA97)
+                             .jmp_far(self.module_base + 0x3BCD7) # was 0x3BA97
                              )
 
         self.custom_memory_current_offset += len(bean_died_routine)
@@ -1232,13 +1252,13 @@ class BeanPatcher:
                 patch.revert()
             self.save_patches.clear()
         else:
-            file_addr = self.module_base + 0x133a08  # this is a big lump of emptiness at the end of the .text region, which is easy to work with
+            file_addr = self.module_base + 0x139CE8 # was 133A08 # this is a big lump of emptiness at the end of the .text region, which is easy to work with
             file_bytes = seeded_save_file.encode("utf-16le") + b"\x00\x00"
             self.process.write_bytes(file_addr, file_bytes, len(file_bytes))
-            load_patch = Patch("save_load", self.module_base + 0x16822, self.process).lea_rax_addr(file_addr)
-            save_patch = Patch("save_save", self.module_base + 0x169e2, self.process).lea_rax_addr(file_addr)
-            attr_patch = Patch("save_attr", self.module_base + 0x1692b, self.process).lea_rax_addr(file_addr)
-            delete_patch = Patch("save_delete", self.module_base + 0x16753, self.process).lea_rax_addr(file_addr)
+            load_patch = Patch("save_load", self.module_base + 0x16A32, self.process).lea_rax_addr(file_addr) # was 0x16822
+            save_patch = Patch("save_save", self.module_base + 0x16C12, self.process).lea_rax_addr(file_addr) # was 0x169E2
+            attr_patch = Patch("save_attr", self.module_base + 0x16B5B, self.process).lea_rax_addr(file_addr) # was 0x1692B
+            delete_patch = Patch("save_delete", self.module_base + 0x16963, self.process).lea_rax_addr(file_addr) # was 0x16753
             if load_patch.apply() and load_patch.name not in self.save_patches:
                 self.save_patches[load_patch.name] = load_patch
             if save_patch.apply() and save_patch.name not in self.save_patches:
@@ -1258,7 +1278,7 @@ class BeanPatcher:
             self.change_save_file_name(seeded_save_file)
             self.process.write_uchar(self.application_state_address + 0x400 + 0x750cc, 1)  # return to title screen to reload new save file
             self.process.write_uchar(self.application_state_address + 0x40C, 0)  # set current save slot to 0
-            self.process.write_uchar(self.module_base + 0x1f17e, 1)  # disable load game menu
+            self.process.write_uchar(self.module_base + 0x1F3A8, 1)  # was 0x1F17E # disable load game menu
             self.save_file = seeded_save_file
             return True
         return False
@@ -1271,7 +1291,7 @@ class BeanPatcher:
         if seeded_save_file != self.save_file:
             self.change_save_file_name(seeded_save_file)
             self.process.write_uchar(self.application_state_address + 0x400 + 0x750cc, 1)  # return to title screen to reload new save file
-            self.process.write_uchar(self.module_base + 0x1f17e, 2)  # enable load game menu
+            self.process.write_uchar(self.module_base + 0x1F3A8, 2)  # was 0x1F17E # enable load game menu
             self.save_file = seeded_save_file
             return True
         return False
@@ -1306,7 +1326,7 @@ class BeanPatcher:
         This patch disables darkness in the game, causing all rooms to be equally lit across all tiles.
         Mostly useful for debugging.
         """
-        self.fullbright_patch = Patch("fullbright", 0x140102e63, self.process).add_bytes(b"\xeb\x19")
+        self.fullbright_patch = Patch("fullbright", self.module_base + 0x103123, self.process).add_bytes(b"\xeb\x19") # was 102E63
 
     def revert_patches(self):
         if not self.attached_to_process:

--- a/worlds/animal_well/bean_patcher.py
+++ b/worlds/animal_well/bean_patcher.py
@@ -635,8 +635,6 @@ class BeanPatcher:
 
         self.generate_room_palette_override_patch()
 
-        ##### self.apply_input_reader_patch()
-
         self.apply_pause_menu_patch()
 
         self.generate_fullbright_patch()
@@ -850,7 +848,7 @@ class BeanPatcher:
         self.process.write_bytes(self.text_lookup_table_address + 0x20, self.custom_memory_current_offset.to_bytes(8, "little", signed=False), 8) # was 2D93F00 # then 0x142D9AF20
         self.custom_memory_current_offset += len(warp_to_hub_text)
         pause_menu_increase_option_count_1_patch = (
-            Patch("pause_menu_increase_option_count_1_patch", self.find_pattern("83 fe 01 7f 3f 83 c6 01") + 3, self.process) # was 0x43cf7 43f87
+            Patch("pause_menu_increase_option_count_1_patch", self.find_pattern("83 fe 01 7f 3f 83 c6 01") + 2, self.process) # was 0x43cf7 43f87
             .add_bytes(b"\x02"))
         pause_menu_increase_option_count_2_patch = (
             Patch("pause_menu_increase_option_count_2_patch", self.find_pattern("48 83 fe 02 74 11 44 8b 64 f4 58") + 3, self.process) # was 44052 442e2

--- a/worlds/animal_well/bean_patcher.py
+++ b/worlds/animal_well/bean_patcher.py
@@ -1,3 +1,5 @@
+import math
+import random
 import string
 import pymem
 import pymem.ressources.kernel32
@@ -69,57 +71,115 @@ def base36(n):
 
 # Extending the Patch class with some Animal Well specific methods
 class Patch(Patch):
+    # region FunctionOffsets
+    function_addresses = {}
+    function_addresses["draw_small_text"]: int = 0
+    function_addresses["draw_big_text"]: int = 0
+    function_addresses["draw_symbol"]: int = 0
+    function_addresses["draw_sprite"]: int = 0
+    function_addresses["get_sprite"]: int = 0
+    function_addresses["push_shader_to_stack"]: int = 0
+    function_addresses["pop_shader_from_stack"]: int = 0
+    function_addresses["push_color_to_stack"]: int = 0
+    function_addresses["pop_color_from_stack"]: int = 0
+    function_addresses["pop_from_position_stack"]: int = 0
+    function_addresses["set_tall_text_mode"]: int = 0
+    function_addresses["set_current_color"]: int = 0
+    function_addresses["set_current_shader"]: int = 0
+    function_addresses["get_key_pressed"]: int = 0
+    function_addresses["get_gamepad_button_pressed"]: int = 0
+    function_addresses["get_an_item"]: int = 0
+    function_addresses["warp"]: int = 0
+    function_addresses["update_player_state"]: int = 0
+    # endregion
+
+    # region OtherOffsets
+    STEP_AND_TIME_DISPLAY_ORIGINAL_VALUES = {
+        0x507A9 + 2: 2.0,  # was 0x504fb
+        0x507A9 + 6: 2.0,  # was 0x504ff
+        0x507ED + 1: 6,  # was 0x5053e
+        0x507F2 + 1: 6,  # was 0x50543
+        0x50809 + 1: 7,  # was 0x5055a
+        0x5080E + 1: 5,  # was 0x5055f
+        0x506C5 + 2: 310.0,  # was 0x50417
+        0x506C5 + 6: 3.0,  # was 0x5041b
+        0x506FE + 1: 280,  # was 0x5044f
+        0x50703 + 1: 5,  # was 0x50454
+        0x50730 + 1: 278,  # was 0x50481
+        0x50735 + 1: 6,  # was 0x50486
+        0x50762 + 1: 279,  # was 0x504b3
+        0x50767 + 1: 5  # was 0x504b8
+    }
+    STEP_AND_TIME_DISPLAY_UPDATED_VALUES = {
+        0x507A9 + 2: 2.0,  # was 0x504fb
+        0x507A9 + 6: 2.0 + 5,  # was 0x504ff
+        0x507ED + 1: 6,  # was 0x5053e
+        0x507F2 + 1: 6 + 5,  # was 0x50543
+        0x50809 + 1: 7,  # was 0x5055a
+        0x5080E + 1: 5 + 5,  # was 0x5055f
+        0x506C5 + 2: 310.0,  # was 0x50417
+        0x506C5 + 6: 3.0 + 5,  # was 0x5041b
+        0x506FE + 1: 280,  # was 0x5044f
+        0x50703 + 1: 5 + 5,  # was 0x50454
+        0x50730 + 1: 278,  # was 0x50481
+        0x50735 + 1: 6 + 5,  # was 0x50486
+        0x50762 + 1: 279,  # was 0x504b3
+        0x50767 + 1: 5 + 5  # was 0x504b8
+    }
+
+    # endregion
+
     def push_shader_to_stack(self, shader_id):
         """
         Pushes a new shader to the shader stack
         """
-        return self.mov_ecx(shader_id).call_via_rax(push_shader_to_stack)
+        return self.mov_ecx(shader_id).call_via_rax(self.function_addresses["push_shader_to_stack"])
 
     def pop_shader_from_stack(self):
         """
         Pops a new shader from the shader stack
         """
-        return self.call_via_rax(pop_shader_from_stack)
+        return self.call_via_rax(self.function_addresses["pop_shader_from_stack"])
 
     def push_color_to_stack(self, color):
         """
         Pushes a new color to the color stack
         color: new color in the format #AABBGGRR
         """
-        return self.mov_ecx(color).call_via_rax(push_color_to_stack)
+        return self.mov_ecx(color).call_via_rax(self.function_addresses["push_color_to_stack"])
 
     def pop_color_from_stack(self):
         """
         Pops a new color from the color stack
         """
-        return self.call_via_rax(pop_color_from_stack)
+        return self.call_via_rax(self.function_addresses["pop_color_from_stack"])
 
     def pop_from_position_stack(self):
         """
         Pops a position from the position stack
         """
-        return self.call_via_rax(pop_from_position_stack)
+        return self.call_via_rax(self.function_addresses["pop_from_position_stack"])
 
     def set_tall_text_mode(self, value):
         """
         Sets whether text will be drawn extra tall or normal
         value: 1 -> Tall Text, 0 -> Normal Text
         """
-        return self.mov_ecx(value).call_via_rax(set_tall_text_mode)
+        return self.mov_ecx(value).call_via_rax(self.function_addresses["set_tall_text_mode"])
 
     def set_current_shader(self, shader_id):
         """
         Sets the shader on the top of the stack
         shader_id: which shader to switch to
         """
-        return self.mov_ecx(shader_id).call_via_rax(set_current_shader)
+        return self.mov_ecx(shader_id).call_via_rax(self.function_addresses["set_current_shader"])
 
     def set_current_color(self, color):
         """
         Sets the color on the top of the stack
         colo: new color in the format #AABBGGRR
         """
-        return self.mov_ecx(color).call_via_rax(set_current_color)
+        return self.mov_ecx(color).call_via_rax(self.function_addresses["set_current_color"])
 
     def draw_small_text(self, x, y, text_address):
         """
@@ -128,7 +188,7 @@ class Patch(Patch):
         y: y position
         text_address: location in the process's memory where the Unicode text is stored
         """
-        return self.mov_ecx(x).mov_edx(y).mov_to_rax(text_address).mov_rax_to_r8().call_via_rax(draw_small_text)
+        return self.mov_ecx(x).mov_edx(y).mov_to_rax(text_address).mov_rax_to_r8().call_via_rax(self.function_addresses["draw_small_text"])
 
     def draw_big_text(self, x, y, text_address):
         """
@@ -137,7 +197,7 @@ class Patch(Patch):
         y: y position
         text_address: location in the process's memory where the Unicode text is stored
         """
-        return self.mov_ecx(x).mov_edx(y).mov_to_rax(text_address).mov_rax_to_r8().call_via_rax(draw_big_text)
+        return self.mov_ecx(x).mov_edx(y).mov_to_rax(text_address).mov_rax_to_r8().call_via_rax(self.function_addresses["draw_big_text"])
 
     def draw_symbol(self, x, y, sprite_id, frame, arg5, arg6, arg7):
         """
@@ -151,7 +211,7 @@ class Patch(Patch):
         arg7: idk
         """
         return (self.mov_ecx(x).mov_edx(y).mov_r8(sprite_id).mov_r9(frame).push(0).push(arg7).push(arg6).push(arg5)
-                .push(0).push(0).push(0).push(0).call_far(draw_symbol).add_rsp(0x40))
+                .push(0).push(0).push(0).push(0).call_far(self.function_addresses["draw_symbol"]).add_rsp(0x40))
 
     def draw_symbol_pointer_x_and_y(self, x_address, y_address, sprite_id, frame, arg5, arg6, arg7):
         """
@@ -166,7 +226,7 @@ class Patch(Patch):
         """
         return (self.mov_to_rax(x_address).mov_rax_pointer_contents_to_rcx().mov_to_rax(y_address)
                 .mov_rax_pointer_contents_to_rdx().mov_r8(sprite_id).mov_r9(frame).push(0).push(arg7).push(arg6)
-                .push(arg5).push(0).push(0).push(0).push(0).call_far(draw_symbol).add_rsp(0x40))
+                .push(arg5).push(0).push(0).push(0).push(0).call_far(self.function_addresses["draw_symbol"]).add_rsp(0x40))
 
     def warp(self, player, room_x, room_y, tile_x, tile_y, map_to_warp):
         """
@@ -184,12 +244,12 @@ class Patch(Patch):
                 .mov_rdx((room_y << 32) + room_x)
                 .mov_r8((tile_y << 32) + tile_x)
                 .mov_r9(map_to_warp)
-                .call_far(warp))
+                .call_far(self.function_addresses["warp"]))
 
     def get_key_pressed(self, key):
         return (self
                 .mov_ecx(key)
-                .call_far(get_key_pressed))
+                .call_far(self.function_addresses["get_key_pressed"]))
 
     def get_an_item(self, save_slot_address, item_id, egg_position=0, location_id=0xff):
         return (self
@@ -197,97 +257,20 @@ class Patch(Patch):
                 .mov_rdx(item_id)
                 .mov_r8(egg_position)
                 .mov_r9(location_id)
-                .call_far(get_an_item))
+                .call_far(self.function_addresses["get_an_item"]))
 
     def get_sprite(self, sprite_id):
         """
         Retrieves a sprite based on its sprite_id
         """
-        return self.mov_cl(sprite_id).call_via_rax(get_sprite)
+        return self.mov_cl(sprite_id).call_via_rax(self.function_addresses["get_sprite"])
 
     def update_player_state(self, player, state, save):
         """
         Updates the player's state
         """
-        return self.mov_rcx(player).mov_rdx(state).mov_r8(save).call_far(update_player_state)
+        return self.mov_rcx(player).mov_rdx(state).mov_r8(save).call_far(self.function_addresses["update_player_state"])
 
-
-# region FunctionOffsets
-# Accurate as of AW file version 1.0.0.18
-# draw_small_text: int = 0x14006E3F0
-# draw_big_text: int = 0x14006DE30
-# draw_symbol: int = 0x14006A6C0
-# draw_sprite: int = 0x14001AEC0
-# get_sprite: int = 0x140063CA0
-# push_shader_to_stack: int = 0x140017840
-# pop_shader_from_stack: int = 0x1400178A0
-# push_color_to_stack: int = 0x1400177D0
-# pop_color_from_stack: int = 0x140017830
-# pop_from_position_stack: int = 0x140017920
-# set_tall_text_mode: int = 0x14006DC00
-# set_current_color: int = 0x1400177B0
-# set_current_shader: int = 0x14001A280
-# get_key_pressed: int = 0x140011C70
-# get_gamepad_button_pressed: int = 0x140011EA0
-# get_an_item: int = 0x1400C15C0
-# warp: int = 0x140074DD0
-# update_player_state: int = 0x1400662F0
-
-# Accurate as of AW file version 1.0.0.20
-draw_small_text: int = 0x14006E6F0
-draw_big_text: int = 0x14006E130
-draw_symbol: int = 0x14006A9B0 # jumps to 0x14001A1C0
-draw_sprite: int = 0x14001B0F0
-get_sprite: int = 0x140063FA0 # jumps to 0x14001A850
-push_shader_to_stack: int = 0x140017A70
-pop_shader_from_stack: int = 0x140017AD0
-push_color_to_stack: int = 0x140017A00
-pop_color_from_stack: int = 0x140017A60
-pop_from_position_stack: int = 0x140017B50
-set_tall_text_mode: int = 0x14006DF00
-set_current_color: int = 0x1400179E0
-set_current_shader: int = 0x14001A4B0
-get_key_pressed: int = 0x140011C70
-get_gamepad_button_pressed: int = 0x140011EA0
-get_an_item: int = 0x1400C1870
-warp: int = 0x140075080
-update_player_state: int = 0x1400665F0
-# endregion
-
-# region OtherOffsets
-STEP_AND_TIME_DISPLAY_ORIGINAL_VALUES = {
-    0x507A9 + 2: 2.0, # was 0x504fb
-    0x507A9 + 6: 2.0, # was 0x504ff
-    0x507ED + 1: 6, # was 0x5053e
-    0x507F2 + 1: 6, # was 0x50543
-    0x50809 + 1: 7, # was 0x5055a
-    0x5080E + 1: 5, # was 0x5055f
-    0x506C5 + 2: 310.0, # was 0x50417
-    0x506C5 + 6: 3.0, # was 0x5041b
-    0x506FE + 1: 280, # was 0x5044f
-    0x50703 + 1: 5, # was 0x50454
-    0x50730 + 1: 278, # was 0x50481
-    0x50735 + 1: 6, # was 0x50486
-    0x50762 + 1: 279, # was 0x504b3
-    0x50767 + 1: 5 # was 0x504b8
-}
-STEP_AND_TIME_DISPLAY_UPDATED_VALUES = {
-    0x507A9 + 2: 2.0, # was 0x504fb
-    0x507A9 + 6: 2.0 + 5, # was 0x504ff
-    0x507ED + 1: 6, # was 0x5053e
-    0x507F2 + 1: 6 + 5, # was 0x50543
-    0x50809 + 1: 7, # was 0x5055a
-    0x5080E + 1: 5 + 5, # was 0x5055f
-    0x506C5 + 2: 310.0, # was 0x50417
-    0x506C5 + 6: 3.0 + 5, # was 0x5041b
-    0x506FE + 1: 280, # was 0x5044f
-    0x50703 + 1: 5 + 5, # was 0x50454
-    0x50730 + 1: 278, # was 0x50481
-    0x50735 + 1: 6 + 5, # was 0x50486
-    0x50762 + 1: 279, # was 0x504b3
-    0x50767 + 1: 5 + 5 # was 0x504b8
-}
-# endregion
 
 # region Other Constants
 HEADER_LENGTH = 0x18
@@ -384,6 +367,8 @@ class BeanPatcher:
         self.unstuck_pos_y = 0x74
         self.unstuck_map = 0
 
+        self.text_lookup_table_address: int = 0
+
         self.fullbright_patch: Optional[Patch] = None
 
         self.cmd_prompt = False
@@ -464,7 +449,51 @@ class BeanPatcher:
             self.log_error("Can't get base layer address without being attached to a process.")
             return None
 
-        return self.module_base + 0x2BDFE20
+        pattern_address = self.find_pattern("56 57 53 48 83 ec 40 44 89 c8 44 8b 8c 24 80 00 00 00 44 8a 94 24 88 00 00 00 44 8a 9c 24 90 00 00 00 8a 9c 24 98 00 00 00", True)
+
+        base_layer_address = self.find_relative_address_from_instruction(pattern_address, 3)
+
+        return base_layer_address
+
+    def find_pattern(self, pattern: string, add_length: bool = False) -> int:
+        if pattern is None:
+            self.log_error("Invalid or missing pattern.")
+            return -1
+
+        if self.aw_module is None:
+            self.log_error("No AW process found. Cannot scan.")
+            return -1
+
+        # self.log_info(f"Searching for pattern '{pattern}'")
+
+        byte_count = len(pattern.split(' '))
+
+        pattern_bytes = bytes("\\x" + pattern.replace(" ", "\\x"), "utf-8")
+        # self.log_info(f"Pattern_bytes: {pattern_bytes}")
+
+        address = self.process.pattern_scan_module(pattern_bytes, self.aw_module)
+
+        if address is None:
+            self.log_error(f"Failed to find pattern '{pattern}'!")
+            raise ValueError
+
+        if add_length:
+            # self.log_info(f"Address: {hex(address + byte_count)}")
+            return address + byte_count
+        else:
+            # self.log_info(f"Address: {hex(address)}")
+            return address
+
+    def find_relative_address_from_instruction(self, address: int, opcode_length: int = 3) -> int:
+        if self.process is None:
+            self.log_error("No process handle provided. Cannot find address.")
+            return False
+
+        arg_address = self.process.read_int(address + opcode_length)
+        after_address = address + opcode_length + 4
+
+        return arg_address + after_address
+
 
     def attach_to_process(self, process=None) -> bool:
         if process is not None:
@@ -489,7 +518,9 @@ class BeanPatcher:
 
         self.module_base = self.aw_module.lpBaseOfDll
 
-        application_state_pointer_address = self.module_base + 0x2D255F8 # was 2BD5308
+        application_state_pointer_address = self.find_relative_address_from_instruction(
+            self.find_pattern("0f 29 bc 24 e0 00 00 00 0f 29 b4 24 d0 00 00 00 48 89 cf", True), 3)
+
         if self.log_debug_info:
             self.log_info(f"Attempting to find start address via pointer at {hex(application_state_pointer_address)}")
 
@@ -497,8 +528,77 @@ class BeanPatcher:
         if self.log_debug_info:
             self.log_info(f"application_state address: {hex(self.application_state_address)}")
 
-        self.application_state_address = self.application_state_address
         self.attached_to_process = True
+
+        Patch.function_addresses["draw_small_text"] = self.find_pattern("41 57 41 56 41 55 41 54 56 57 55 53 48 83 ec 58 89 4c 24 54 4d 85 c0 0f 84 b5 00 00 00") # 0x14006E6F0
+        if self.log_debug_info: self.log_info(f"draw_small_text found at {hex(Patch.function_addresses['draw_small_text'])}")
+        Patch.function_addresses["draw_big_text"] = self.find_pattern("41 57 41 56 41 55 41 54 56 57 55 53 48 83 ec 58 4d 85 c0 0f 84 13 01 00 00") # 0x14006E130
+        if self.log_debug_info: self.log_info(f"draw_big_text found at {hex(Patch.function_addresses['draw_big_text'])}")
+        Patch.function_addresses["draw_symbol"] = self.find_pattern("41 57 41 56 56 57 55 53 48 83 ec 78 0f 29 7c 24 60 0f 29 74 24 50") # 0x14006A9B0
+        if self.log_debug_info: self.log_info(f"draw_symbol found at {hex(Patch.function_addresses['draw_symbol'])}")
+        Patch.function_addresses["draw_sprite"] = self.find_pattern("56 57 53 48 83 ec 40 44 89 c8") # 0x14001B0F0
+        if self.log_debug_info: self.log_info(f"draw_sprite found at {hex(Patch.function_addresses['draw_sprite'])}")
+        Patch.function_addresses["get_sprite"] = self.find_pattern("0f b6 c9 48 8d 0c 49 48 c1 e1 04 48 01 c8 48 05 c8 e1 89 00") - 7 # 0x140063FA0
+        if self.log_debug_info: self.log_info(f"get_sprite found at {hex(Patch.function_addresses['get_sprite'])}")
+        Patch.function_addresses["push_shader_to_stack"] = self.find_pattern("4c 63 80 68 dc 89 00 49 8d 50 01 89 90 68 dc 89 00 42 89 8c 80 4c dc 89 00") - 7 # 0x140017A70
+        if self.log_debug_info: self.log_info(f"push_shader_to_stack found at {hex(Patch.function_addresses['push_shader_to_stack'])}")
+        Patch.function_addresses["pop_shader_from_stack"] = self.find_pattern("83 80 68 dc 89 00 ff c3") - 7 # 0x140017AD0
+        if self.log_debug_info: self.log_info(f"pop_shader_from_stack found at {hex(Patch.function_addresses['pop_shader_from_stack'])}")
+        Patch.function_addresses["push_color_to_stack"] = self.find_pattern("4c 63 80 8c dc 89 00 49 8d 50 01 89 90 8c dc 89 00 42 89 8c 80 70 dc 89 00") - 7 # 0x140017A00
+        if self.log_debug_info: self.log_info(f"push_color_to_stack found at {hex(Patch.function_addresses['push_color_to_stack'])}")
+        Patch.function_addresses["pop_color_from_stack"] = self.find_pattern("83 80 8c dc 89 00 ff c3") - 7 # 0x140017A60
+        if self.log_debug_info: self.log_info(f"pop_color_from_stack found at {hex(Patch.function_addresses['pop_color_from_stack'])}")
+        Patch.function_addresses["pop_from_position_stack"] = self.find_pattern("83 80 d0 dc 89 00 ff c3") - 7 # 0x140017B50
+        if self.log_debug_info: self.log_info(f"pop_from_position_stack found at {hex(Patch.function_addresses['pop_from_position_stack'])}")
+        Patch.function_addresses["set_tall_text_mode"] = self.find_pattern("89 88 08 6b 3e 00 c3") - 7 # 0x14006DF00
+        if self.log_debug_info: self.log_info(f"set_tall_text_mode found at {hex(Patch.function_addresses['set_tall_text_mode'])}")
+        Patch.function_addresses["set_current_color"] = self.find_pattern("48 63 90 8c dc 89 00 89 8c 90 6c dc 89 00") - 7 # 0x1400179E0
+        if self.log_debug_info: self.log_info(f"set_current_color found at {hex(Patch.function_addresses['set_current_color'])}")
+        Patch.function_addresses["set_current_shader"] = self.find_pattern("48 63 90 68 dc 89 00 89 8c 90 48 dc 89 00") - 7 # 0x14001A4B0
+        if self.log_debug_info: self.log_info(f"set_current_shader found at {hex(Patch.function_addresses['set_current_shader'])}")
+        Patch.function_addresses["get_key_pressed"] = self.find_relative_address_from_instruction(self.find_pattern("48 89 46 60 48 8d 05 7e e3 ff ff") + 4, 3) # 0x140011C70
+        if self.log_debug_info: self.log_info(f"get_key_pressed found at {hex(Patch.function_addresses['get_key_pressed'])}")
+        Patch.function_addresses["get_gamepad_button_pressed"] = self.find_pattern("53 48 83 ec 20 89 ca") # 0x140011EA0
+        if self.log_debug_info: self.log_info(f"get_gamepad_button_pressed found at {hex(Patch.function_addresses['get_gamepad_button_pressed'])}")
+        Patch.function_addresses["get_an_item"] = self.find_pattern("41 57 41 56 56 57 55 53 48 81 ec 18 01 00 00 44 0f 29 8c 24 00 01 00 00 44 0f 29 84 24 f0 00 00 00 0f 29 bc 24 e0 00 00 00 0f 29 b4 24 d0 00 00 00") # 0x1400C1870
+        if self.log_debug_info: self.log_info(f"get_an_item found at {hex(Patch.function_addresses['get_an_item'])}")
+        Patch.function_addresses["warp"] = self.find_pattern("56 48 83 ec 20 48 89 ce 80 89") # 0x140075080
+        if self.log_debug_info: self.log_info(f"warp found at {hex(Patch.function_addresses['warp'])}")
+        Patch.function_addresses["update_player_state"] = self.find_pattern("41 57 41 56 41 55 41 54 56 57 55 53 48 81 ec 98 00 00 00 0f 29 b4 24 80 00 00 00 48 89 ce c7 41 30 00 00 00 00 c7 81 c0 04 00 00 00 00 00 00") # 0x1400665F0
+        if self.log_debug_info: self.log_info(f"update_player_state found at {hex(Patch.function_addresses['update_player_state'])}")
+
+        # self.text_lookup_table_address = ((self.find_pattern("48 85 c0 75 0e", True) + 7)
+        #                                   + self.process.read_int(self.find_pattern("48 85 c0 75 0e", True) + 3)
+        #                                   - 0x3000)
+
+        self.text_lookup_table_address = ((self.find_pattern("48 63 c1 48 69 c0 20 09 00 00 48 8d 0d") + 27)
+                                          + self.process.read_int(self.find_pattern("48 63 c1 48 69 c0 20 09 00 00 48 8d 0d") + 23))
+        if self.log_debug_info: self.log_info(f"text_lookup_table_address pointer found at {hex(self.text_lookup_table_address)}")
+
+        self.text_lookup_table_address = self.process.read_ulonglong(self.text_lookup_table_address)
+        if self.log_debug_info: self.log_info(f"text_lookup_table_address found at {hex(self.text_lookup_table_address)}")
+
+        Patch.STEP_AND_TIME_DISPLAY_UPDATED_VALUES = {
+            self.find_pattern("48 B9 00 00 00 40 00 00 00 40") + 2: 2.0,  # was 0x504fb
+            self.find_pattern("48 B9 00 00 00 40 00 00 00 40") + 6: 2.0 + 5,  # was 0x504ff
+            self.find_pattern("b9 06 00 00 00 ba 06 00 00 00 49 89 d8") + 1: 6,  # was 0x5053e
+            self.find_pattern("b9 06 00 00 00 ba 06 00 00 00 49 89 d8") + 5 + 1: 6 + 5,  # was 0x50543
+            self.find_pattern("b9 07 00 00 00 ba 05 00 00 00 49 89 d8") + 1: 7,  # was 0x5055a
+            self.find_pattern("b9 07 00 00 00 ba 05 00 00 00 49 89 d8") + 5 + 1: 5 + 5,  # was 0x5055f
+            self.find_pattern("48 B9 00 00 9B 43 00 00 40 40") + 2: 310.0,  # was 0x50417
+            self.find_pattern("48 B9 00 00 9B 43 00 00 40 40") + 6: 3.0 + 5,  # was 0x5041b
+            self.find_pattern("b9 18 01 00 00 ba 05 00 00 00 49 89 d8") + 1: 280,  # was 0x5044f
+            self.find_pattern("b9 18 01 00 00 ba 05 00 00 00 49 89 d8") + 5 + 1: 5 + 5,  # was 0x50454
+            self.find_pattern("b9 16 01 00 00 ba 06 00 00 00 49 89 d8") + 1: 278,  # was 0x50481
+            self.find_pattern("b9 16 01 00 00 ba 06 00 00 00 49 89 d8") + 5 + 1: 6 + 5,  # was 0x50486
+            self.find_pattern("b9 17 01 00 00 ba 05 00 00 00 49 89 d8") + 1: 279,  # was 0x504b3
+            self.find_pattern("b9 17 01 00 00 ba 05 00 00 00 49 89 d8") + 5 + 1: 5 + 5  # was 0x504b
+        }
+
+        Patch.STEP_AND_TIME_DISPLAY_ORIGINAL_VALUES = {}
+
+        for address in Patch.STEP_AND_TIME_DISPLAY_UPDATED_VALUES:
+            Patch.STEP_AND_TIME_DISPLAY_ORIGINAL_VALUES[address] = self.process.read_float(address)
 
         return True
 
@@ -527,7 +627,7 @@ class BeanPatcher:
 
         self.generate_room_palette_override_patch()
 
-        # self.apply_input_reader_patch()
+        ##### self.apply_input_reader_patch()
 
         self.apply_pause_menu_patch()
 
@@ -535,13 +635,13 @@ class BeanPatcher:
 
         self.apply_item_collection_patches()
 
-        self.apply_receive_item_patch()
+        # self.apply_receive_item_patch()
 
-        self.apply_skip_credits_patch()
+        # self.apply_skip_credits_patch()
 
-        self.apply_deathlink_patch()
+        # self.apply_deathlink_patch()
 
-        self.apply_seeded_save_patch()  # the seed is saved in RoomInfo and applied in Connection, and applied here again if AP was connected before AW was launched
+        # self.apply_seeded_save_patch()  # the seed is saved in RoomInfo and applied in Connection, and applied here again if AP was connected before AW was launched
 
         # mural bytes at slot + 0x26eaf
         # default mural bytes at 0x142094600
@@ -593,7 +693,9 @@ class BeanPatcher:
         """
             This patch displays the text "AP Randomizer" on the title screen.
         """
-        main_menu_draw_injection_address = self.module_base + 0x1F255 # 0x1f025
+        # main_menu_draw_injection_address = self.module_base + 0x1F255 # 0x1f025
+        main_menu_draw_injection_address = self.find_pattern("b9 a0 00 00 00 ba ac 00 00 00", True) + 5
+        self.log_info(f"Main_menu_draw_injection_address: {hex(main_menu_draw_injection_address)}")
         self.main_menu_draw_string_addr = self.custom_memory_current_offset
         self.custom_memory_current_offset += TITLE_SCREEN_MAX_TEXT_LENGTH
         main_menu_draw_routine_address = self.custom_memory_current_offset
@@ -634,7 +736,8 @@ class BeanPatcher:
         It additionally pushes the steps and time counters lower on the screen to make room for the new text display.
         This patch can also be extended in the future to display other things in-game.
         """
-        game_draw_injection_address = self.module_base + 0x5093B #0x5068b
+        # game_draw_injection_address = self.module_base + 0x5093B #0x5068b
+        game_draw_injection_address = self.find_pattern("0f 28 b4 24 60 01 00 00 0f 28 bc 24 70 01 00 00 44 0f 28 84 24 80 01 00 00 48 81 c4 98 01 00 00", True) - 7
         self.game_draw_routine_string_addr = self.custom_memory_current_offset
         self.custom_memory_current_offset += self.game_draw_routine_string_size + 0x10
 
@@ -649,11 +752,11 @@ class BeanPatcher:
         game_draw_code_address = self.custom_memory_current_offset
         draw_trampoline_patch = (Patch("game_draw_trampoline", game_draw_injection_address, self.process)
                                  .mov_to_rax(game_draw_code_address).jmp_rax().nop())
-        for offset, value in STEP_AND_TIME_DISPLAY_UPDATED_VALUES.items():
-            if value is int:
-                self.process.write_uint(self.module_base + offset, value)
-            elif value is float:
-                self.process.write_float(self.module_base + offset, value)
+        for address, value in Patch.STEP_AND_TIME_DISPLAY_UPDATED_VALUES.items():
+            if isinstance(value, int):
+                self.process.write_uint(address, value)
+            elif isinstance(value, float):
+                self.process.write_float(address, value)
         client_text_display_x = 1
         client_text_display_y = 1  # lines the text up with the very top tile row
         # TODO: store the display color somewhere so we can change it appropriate to each message we show
@@ -714,7 +817,7 @@ class BeanPatcher:
             # 0x69 -> blocked, 0x72 -> wake up, 0x73 -> locked, 0xae -> beacon, 0xb2 -> travel
             .mov_to_rax(0xc)
             .mov_rax_to_rsp_offset(0x68)
-            .jmp_far(self.module_base + 0x43F6F)  # 84 -> control panel)  # was 0x140043cdf
+            .jmp_far(self.find_pattern("48 b8 0c 00 00 00 ec ff ff ff 48 89 44 24 60", True))  # 84 -> control panel)  # was 0x140043cdf
             .nop(0x10))
         self.custom_memory_current_offset += len(pause_menu_patch_update_option_text)
         pause_menu_resume_and_warp_patch = (
@@ -725,39 +828,44 @@ class BeanPatcher:
             .warp(self.player_address, self.unstuck_room_x, self.unstuck_room_y, self.unstuck_pos_x, self.unstuck_pos_y, self.unstuck_map)
             .pop_r9().pop_r8().pop_rdx().pop_rcx()
             .mov_to_rax(self.application_state_address)
-            .jmp_far(self.module_base + 0x444B3) # was 0x44223
+            .jmp_far(self.find_pattern("8b 88 44 36 09 00 83 e1 fe 83 f9 08 75 2b")) # was 0x44223
             .nop(0x10))
         self.custom_memory_current_offset += len(pause_menu_resume_and_warp_patch)
         pause_menu_patch_update_option_text_trampoline = (
-            Patch("pause_menu_patch_update_option_text_trampoline", self.module_base + 0x43F54, self.process) # was 43CC4
+            Patch("pause_menu_patch_update_option_text_trampoline", self.find_pattern("0f 29 44 24 50 48 b8 0c 00 00 00 ec ff ff ff 48 89 44 24 60") - 7, self.process) # was 43CC4
             .jmp_far(pause_menu_patch_update_option_text.base_address)
             .nop(0xd))
         warp_to_hub_text = "warp to hub".encode("utf-16le") + b"\x00\x00"
         self.process.write_bytes(self.custom_memory_current_offset, warp_to_hub_text, len(warp_to_hub_text))
-        self.process.write_bytes(self.module_base + 0x2D9AF20, self.custom_memory_current_offset.to_bytes(8, "little", signed=False), 8) # was 2D93F00
+        self.log_info(f"text_lookup_table_address: {hex(self.text_lookup_table_address)}, text_lookup_table_address + 0x20: {hex(self.text_lookup_table_address + 0x20)}")
+        self.log_info(f"location of new 'warp to hub' text: {hex(self.custom_memory_current_offset)}")
+        self.process.write_bytes(self.text_lookup_table_address + 0x20, self.custom_memory_current_offset.to_bytes(8, "little", signed=False), 8) # was 2D93F00 # then 0x142D9AF20
         self.custom_memory_current_offset += len(warp_to_hub_text)
         pause_menu_increase_option_count_1_patch = (
-            Patch("pause_menu_increase_option_count_1_patch", self.module_base + 0x43F87, self.process) # was 0x43cf7
+            Patch("pause_menu_increase_option_count_1_patch", self.find_pattern("8b b0 10 36 09 00 83 fe 01 7f 3f") + 8, self.process) # was 0x43cf7 43f87
             .add_bytes(b"\x02"))
         pause_menu_increase_option_count_2_patch = (
-            Patch("pause_menu_increase_option_count_2_patch", self.module_base + 0x442E2, self.process) # was 44052
+            Patch("pause_menu_increase_option_count_2_patch", self.find_pattern("e8 51 9e 02 00 48 83 fe 02 74 11") + 8, self.process) # was 44052 442e2
             .add_bytes(b"\x03"))
         pause_menu_on_confirm_patch = (
             Patch("pause_menu_on_confirm_patch", self.custom_memory_current_offset, self.process)
-            .call_far(self.module_base + 0x6EF30) # was 0x6ec30
+            .call_far(self.find_pattern("56 48 83 ec 40 48 be a0 00 00 00 2d 00 00 00")) # was 0x6ec30
             .push_rcx().push_rdx().push_r8().push_r9()
-            .mov_from_absolute_address_to_eax(self.application_state_address + 0x93610)
+            .mov_from_absolute_address_to_eax(self.application_state_address + 0x93610) # currentMenuSelection
             .cmp_eax(2)
             .je_far(pause_menu_resume_and_warp_patch.base_address)
             .pop_r9().pop_r8().pop_rdx().pop_rcx()
             .mov_rdx(self.application_state_address)
             .cmp_ebx(0xe10)
-            .jl_far(self.module_base + 0x44621) # was 0x140044391
-            .jmp_far(self.module_base + 0x445EB) # was 0x14004435b
+            .jl_far(self.find_pattern("4c 8d 82 00 04 00 00 48 81 c2 70 36 09 00 b9 02 00 00 00 e8 e7 41 fe ff")) # was 0x140044391 0x140044621
+            .jmp_far(self.find_pattern("8b 82 44 36 09 00 89 82 40 36 09 00 c7 82 10 36 09 00 00 00 00 00 c7 82"
+                                       " 18 36 09 00 00 00 00 00 c7 82 44 36 09 00 09 00 00 00 c7 82 48 36 09 00 00 00 00 00")) # was 0x14004435b 0x1400445eb
             .nop(0x10))
         self.custom_memory_current_offset += len(pause_menu_on_confirm_patch)
         pause_menu_patch_on_confirm_trampoline_patch = (
-            Patch("pause_menu_patch_on_confirm_trampoline_patch", self.module_base + 0x445D7, self.process) # was 0x140044347
+            Patch("pause_menu_patch_on_confirm_trampoline_patch",
+                  self.find_pattern("c7 80 10 36 09 00 00 00 00 00 c7 80 18 36 09 00 00 00 00 00 c7"
+                                    " 80 44 36 09 00 04 00 00 00 c7 80 48 36 09 00 00 00 00 00", True) + 7, self.process) # was 0x140044347 1400445d7
             .jmp_far(pause_menu_on_confirm_patch.base_address)
             .nop(6))
         if self.log_debug_info:
@@ -864,8 +972,8 @@ class BeanPatcher:
         """
         Disables the built-in anti-cheat that rolls back changes that occur to the player outside the frame function.
         """
-        frame_anticheat_address = self.module_base + 0x6072F # 0x6048A
-        frame_anticheat_complete_address = self.module_base + 0x60863 # 0x605B3
+        frame_anticheat_address = self.find_pattern("66 0f 76 c0 eb 15") - 7
+        frame_anticheat_complete_address = self.find_pattern("8b 81 cc 54 07 00 83 c0 ff 83 f8 04 77 7a") - 7 # 0x605B3
         disable_anticheat_patch = Patch(
             "disable_anti-cheat", frame_anticheat_address, self.process).jmp_far(frame_anticheat_complete_address)
         if self.log_debug_info:
@@ -912,7 +1020,7 @@ class BeanPatcher:
         if self.log_debug_info:
             self.log_info("Applying room palette override patch...")
         self.room_palette_override_patch = (
-            Patch("override_room_palette", self.module_base + 0x2e26, self.process)
+            Patch("override_room_palette", self.find_pattern("48 69 d2 88 1b 00 00 8b 4c 11 08", True), self.process)
             .mov_to_eax(self.room_palette_override_shader).nop(1))
 
     def apply_item_collection_patches(self):
@@ -927,28 +1035,28 @@ class BeanPatcher:
         but reducing situations where you might be performing a trick when receiving a piece of equipment from
         another player"s game.
         """
-        disable_chest_item_patch = Patch("disable_chest_item", self.module_base + 0xC2B21, self.process).xor_r8d_r8d().xor_edx_edx().nop(3) # was 0x1400c2871
-        disable_item_get_dialog_patch = Patch("disable_item_get_dialog", self.module_base + 0xC2411, self.process).nop(5) # was 0x1400c2161
+        disable_chest_item_patch = Patch("disable_chest_item", self.find_pattern("44 8b 47 18 0f b7 57 10 4c 89 f1"), self.process).xor_r8d_r8d().xor_edx_edx().nop(3) # was 0x1400c2871, 0x1400C2B21
+        disable_item_get_dialog_patch = Patch("disable_item_get_dialog", self.find_pattern("66 bf a1 00 48 89 c2 66 41 b8 a1 00 45 31 c9", True), self.process).nop(5) # was 0x1400c2161, 0x1400C2411
         # match, pencil, stethoscope, officeKey, stamps, pedometer, rabbitFig, mockDisc, cake, regularKey, stopwatch, sMedal, eMedal, questionKey
-        disable_egg_get_dialog_patch = Patch("disable_egg_get_dialog", self.module_base + 0xC2753, self.process).nop(5) # was 0x1400c24a3
-        disable_lantern_get_dialog_patch = Patch("disable_lantern_get_dialog", self.module_base + 0xC1F32, self.process).nop(5) # was 0x1400c1c82
-        disable_flute_get_dialog_patch = Patch("disable_flute_get_dialog", self.module_base + 0xC24F1, self.process).nop(5) # was 0x1400c2241
-        disable_bubble_get_dialog_patch = Patch("disable_bubble_get_dialog", self.module_base + 0xC249A, self.process).nop(5) # was 0x1400c21ea
-        disable_uv_get_dialog_patch = Patch("disable_uv_get_dialog", self.module_base + 0xC1F89, self.process).nop(5) # was 0x1400c1cd9
-        disable_yoyo_get_dialog_patch = Patch("disable_yoyo_get_dialog", self.module_base + 0xC21D1, self.process).nop(5) # was 0x1400c1f21
-        disable_slink_get_dialog_patch = Patch("disable_slink_get_dialog", self.module_base + 0xC1E70, self.process).nop(5) # was 0x1400c1bc0
-        disable_remote_get_dialog_patch = Patch("disable_remote_get_dialog", self.module_base + 0xC23CA, self.process).nop(5) # was 0x1400c211a
-        disable_wheel_get_dialog_patch = Patch("disable_wheel_get_dialog", self.module_base + 0xC2578, self.process).nop(5) # was 0x1400c22c8
-        disable_wheel_get_without_saving_cats_dialog_patch = Patch("disable_wheel_get_without_saving_cats_dialog", self.module_base + 0xC2362, self.process).nop(5) # was 0x1400c20b2
-        disable_ball_get_dialog_patch = Patch("disable_ball_get_dialog", self.module_base + 0xC22BD, self.process).nop(5) # was 0x1400c200d
-        disable_top_get_dialog_patch = Patch("disable_top_get_dialog", self.module_base + 0xC2266, self.process).nop(5) # was 0x1400c1fb6
-        disable_egg65_get_dialog_patch = Patch("disable_egg65_get_dialog", self.module_base + 0xC1B6E, self.process).nop(5) # was 0x1400c18be
-        disable_bbwand_get_dialog_patch = Patch("disable_bbwand_get_dialog", self.module_base + 0xC2025, self.process).nop(5) # was 0x1400c1d75
-        disable_fannypack_get_dialog_patch = Patch("disable_fannypack_get_dialog", self.module_base + 0xC2131, self.process).nop(5) # was 0x1400c1e81
-        disable_firecracker_get_dialog_patch = Patch("disable_firecracker_get_dialog", self.module_base + 0x2CD89, self.process).nop(5) # was 0x14002cb59
-        disable_firecracker_selected_equipment_patch = Patch("disable_firecracker_selected_equipment", self.module_base + 0x2CD1A, self.process).nop(5) # was 0x14002caea
-        disable_mockdisc_flags_check_patch = Patch("disable_mockdisc_flags_check", self.module_base + 0xC12B3, self.process).add_bytes(bytearray([0xEB])) # was 0x1400c1003
-        disable_sack_spawn_patch = Patch("disable_sack_spawn_patch", self.module_base + 0x749C0, self.process).add_bytes(bytearray([0xc3])) # was 0x140074710
+        disable_egg_get_dialog_patch = Patch("disable_egg_get_dialog", self.find_pattern("48 89 fa 49 89 d8 45 31 c9", True), self.process).nop(5) # was 0x1400c24a3, 0x1400C2753
+        disable_lantern_get_dialog_patch = Patch("disable_lantern_get_dialog", self.find_pattern("31 f6 48 89 c2 66 41 b8 94 01 45 31 c9", True), self.process).nop(5) # was 0x1400c1c82, 0x1400C1F32
+        disable_flute_get_dialog_patch = Patch("disable_flute_get_dialog", self.find_pattern("31 f6 48 89 c2 66 41 b8 93 01 45 31 c9", True), self.process).nop(5) # was 0x1400c2241, 0x1400C24F1
+        disable_bubble_get_dialog_patch = Patch("disable_bubble_get_dialog", self.find_pattern("31 f6 48 89 c2 66 41 b8 8f 01 45 31 c9", True), self.process).nop(5) # was 0x1400c21ea, 0x1400C249A
+        disable_uv_get_dialog_patch = Patch("disable_uv_get_dialog", self.find_pattern("31 f6 48 89 c2 66 41 b8 95 01 45 31 c9", True), self.process).nop(5) # was 0x1400c1cd9, 0x1400C1F89
+        disable_yoyo_get_dialog_patch = Patch("disable_yoyo_get_dialog", self.find_pattern("31 f6 48 89 c2 66 41 b8 90 01 45 31 c9", True), self.process).nop(5) # was 0x1400c1f21, 0x1400C21D1
+        disable_slink_get_dialog_patch = Patch("disable_slink_get_dialog", self.find_pattern("31 f6 48 89 c2 66 41 b8 91 01 45 31 c9", True), self.process).nop(5) # was 0x1400c1bc0, 0x1400C1E70
+        disable_remote_get_dialog_patch = Patch("disable_remote_get_dialog", self.find_pattern("31 f6 48 89 c2 66 41 b8 d3 01 45 31 c9", True), self.process).nop(5) # was 0x1400c211a, 0x1400C23CA
+        disable_wheel_get_dialog_patch = Patch("disable_wheel_get_dialog", self.find_pattern("31 f6 48 89 c2 66 41 b8 84 02 45 31 c9", True), self.process).nop(5) # was 0x1400c22c8, 0x1400C2578
+        disable_wheel_get_without_saving_cats_dialog_patch = Patch("disable_wheel_get_without_saving_cats_dialog", self.find_pattern("48 c7 44 24 20 00 00 00 00 48 8d 54 24 50 66 41 b8 84 02 45 31 c9", True), self.process).nop(5) # was 0x1400c20b2, 0x1400C2362
+        disable_ball_get_dialog_patch = Patch("disable_ball_get_dialog", self.find_pattern("31 f6 48 89 c2 66 41 b8 7e 02 45 31 c9", True), self.process).nop(5) # was 0x1400c200d, 0x1400C22BD
+        disable_top_get_dialog_patch = Patch("disable_top_get_dialog", self.find_pattern("31 f6 48 89 c2 66 41 b8 7b 02 45 31 c9", True), self.process).nop(5) # was 0x1400c1fb6, 0x1400C2266
+        disable_egg65_get_dialog_patch = Patch("disable_egg65_get_dialog", self.find_pattern("48 89 c2 66 41 b8 c6 02", True), self.process).nop(5) # was 0x1400c18be, 0x1400C1B6E
+        disable_bbwand_get_dialog_patch = Patch("disable_bbwand_get_dialog", self.find_pattern("31 f6 48 89 c2 66 41 b8 c5 02 45 31 c9", True), self.process).nop(5) # was 0x1400c1d75, 0x1400C2025
+        disable_fannypack_get_dialog_patch = Patch("disable_fannypack_get_dialog", self.find_pattern("31 f6 48 89 c2 66 41 b8 0d 03 45 31 c9", True), self.process).nop(5) # was 0x1400c1e81, 0x1400C2131
+        disable_firecracker_get_dialog_patch = Patch("disable_firecracker_get_dialog", self.find_pattern("48 89 7c 24 20 48 89 c2 66 41 b8 92 01 45 31 c9", True), self.process).nop(5) # was 0x14002cb59, 0x14002CD89
+        disable_firecracker_selected_equipment_patch = Patch("disable_firecracker_selected_equipment", self.find_pattern("48 89 f1 66 ba 01 00 e8", True) - 1, self.process).nop(5) # was 0x14002caea, 0x14002CD1A
+        disable_mockdisc_flags_check_patch = Patch("disable_mockdisc_flags_check", self.find_pattern("75 2f 8b 4f 14 83 f9 3f 7f 13"), self.process).add_bytes(bytearray([0xEB])) # was 0x1400c1003, 0x1400C12B3
+        disable_sack_spawn_patch = Patch("disable_sack_spawn_patch", self.find_pattern("41 56 56 57 55 53 48 83 ec 20 44 89 cf 49 89 d6 40 8a 6c 24 70"), self.process).add_bytes(bytearray([0xc3])) # was 0x140074710, 0x1400749C0
 
         if self.log_debug_info:
             self.log_info(f"Applying disable_chest_item_patch patch...")
@@ -1106,7 +1214,7 @@ class BeanPatcher:
                 .add_bytes(bytearray([0x41, 0x57, 0x41, 0x56, 0x41, 0x55, 0x48, 0x0F, 0xBE, 0x07, 0x49, 0xBD]))
                 .add_bytes(self.tracker_icons_addr.to_bytes(8, "little"))
                 .add_bytes(bytearray([0x49, 0xC7, 0xC6, 0x0F, 0x00, 0x00, 0x00, 0x49, 0xC7, 0xC7, 0xF0, 0x00, 0x00, 0x00, 0x49, 0x21, 0xC7, 0x4C, 0x21, 0xF0, 0x50, 0x49, 0xC1, 0xEF, 0x02, 0x4D, 0x01, 0xFD, 0x41, 0x8B, 0x4D, 0x00]))
-                .call_via_rax(set_current_color)
+                .call_via_rax(Patch.function_addresses["set_current_color"])
                 .add_bytes(bytearray([0x58, 0x41, 0x5D, 0x41, 0x5E, 0x41, 0x5F]))
                 .add_bytes(bytearray([0x49, 0xBE]))
                 .add_bytes((self.tracker_icons_addr+16).to_bytes(8, "little"))
@@ -1334,7 +1442,7 @@ class BeanPatcher:
         This patch disables darkness in the game, causing all rooms to be equally lit across all tiles.
         Mostly useful for debugging.
         """
-        self.fullbright_patch = Patch("fullbright", self.module_base + 0x103123, self.process).add_bytes(b"\xeb\x19") # was 102E63
+        self.fullbright_patch = Patch("fullbright", self.find_pattern("7e 19 89 c3 48 8b be b0 00 00 00 b9 24 00 00 00"), self.process).add_bytes(b"\xeb\x19") # was 102E63
 
     def revert_patches(self):
         if not self.attached_to_process:
@@ -1353,11 +1461,11 @@ class BeanPatcher:
         self.fullbright_patch = None
         self.room_palette_override_patch = None
 
-        for offset, value in STEP_AND_TIME_DISPLAY_ORIGINAL_VALUES.items():
-            if value is int:
-                self.process.write_uint(self.module_base + offset, value)
-            elif value is float:
-                self.process.write_float(self.module_base + offset, value)
+        for address, value in Patch.STEP_AND_TIME_DISPLAY_ORIGINAL_VALUES.items():
+            if isinstance(value, int):
+                self.process.write_uint(address, value)
+            elif isinstance(value, float):
+                self.process.write_float(address, value)
 
         self.custom_memory_base = None  # TODO: Free this memory back when we're unhooking from AW
         self.custom_memory_current_offset = None
@@ -1403,6 +1511,8 @@ class BeanPatcher:
                 self.process.write_bool(self.bean_has_died_address, False)
                 if self.on_bean_death_function is not None:
                     await self.on_bean_death_function()
+
+        self.enable_room_palette_override(random.randrange(0, 31))
 
     def key_pressed(self, key):
         if self.cmd_keys is None or self.cmd_keys_old is None:
@@ -1548,6 +1658,6 @@ class BeanPatcher:
 
             new_text_bytes = text[0:TITLE_SCREEN_MAX_TEXT_LENGTH-2].encode("utf-16le") + b"\x00\x00"
             self.process.write_bytes(self.main_menu_draw_string_addr, new_text_bytes, len(new_text_bytes))
-            self.process.read_string(self.main_menu_draw_string_addr, TITLE_SCREEN_MAX_TEXT_LENGTH, encoding="utf-16le")
+            #self.process.read_string(self.main_menu_draw_string_addr, TITLE_SCREEN_MAX_TEXT_LENGTH, encoding="utf-16le")
         except Exception as e:
             self.log_error(f"Error while attempting to update title screen text: {e}")

--- a/worlds/animal_well/client.py
+++ b/worlds/animal_well/client.py
@@ -165,7 +165,8 @@ class AnimalWellCommandProcessor(ClientCommandProcessor):
             logger.info(status_text)
 
             if host.animal_well_settings["in_game_tracker"] > tracker_enum.no_tracker:
-                self.ctx.bean_patcher.apply_tracker_patches()
+                pass
+                # self.ctx.bean_patcher.apply_tracker_patches()
             else:
                 self.ctx.bean_patcher.revert_tracker_patches()
 
@@ -369,7 +370,8 @@ class AnimalWellContext(CommonContext):
             self.bean_patcher.update_tracker_text()
             aw_settings = get_settings().animal_well_settings
             if aw_settings.get("in_game_tracker", AWSettings.TrackerSetting.full_tracker) > AWSettings.TrackerSetting.no_tracker:
-                self.bean_patcher.apply_tracker_patches()
+                # self.bean_patcher.apply_tracker_patches()
+                pass
             else:
                 self.bean_patcher.revert_tracker_patches()
 
@@ -1421,7 +1423,8 @@ async def get_animal_well_process_handle(ctx: AnimalWellContext):
             host = get_settings()
             tracker_enum = AWSettings.TrackerSetting
             if host.animal_well_settings["in_game_tracker"] > tracker_enum.no_tracker:
-                ctx.bean_patcher.apply_tracker_patches()
+                pass
+                # ctx.bean_patcher.apply_tracker_patches()
             else:
                 ctx.bean_patcher.revert_tracker_patches()
 

--- a/worlds/animal_well/client.py
+++ b/worlds/animal_well/client.py
@@ -515,7 +515,7 @@ class AnimalWellContext(CommonContext):
     def get_tiles(self, tile_types, map_id=0):
         if self.start_address is None:
             return
-        map_addr = int.from_bytes(self.process_handle.read_bytes(self.bean_patcher.module_base + 0x2BD8E30, 8), byteorder="little") + 0x2d0 + map_id * 0x1b8f84
+        map_addr = int.from_bytes(self.process_handle.read_bytes(self.bean_patcher.base_layer_address, 8), byteorder="little") + 0x2d0 + map_id * 0x1b8f84
         room_count = int.from_bytes(self.process_handle.read_bytes(map_addr, 2), byteorder="little")
         map_data = self.process_handle.read_bytes(map_addr + 4, 0x1b8f84)
         for room_idx in range(room_count):

--- a/worlds/animal_well/client.py
+++ b/worlds/animal_well/client.py
@@ -165,8 +165,7 @@ class AnimalWellCommandProcessor(ClientCommandProcessor):
             logger.info(status_text)
 
             if host.animal_well_settings["in_game_tracker"] > tracker_enum.no_tracker:
-                pass
-                # self.ctx.bean_patcher.apply_tracker_patches()
+                self.ctx.bean_patcher.apply_tracker_patches()
             else:
                 self.ctx.bean_patcher.revert_tracker_patches()
 
@@ -370,7 +369,7 @@ class AnimalWellContext(CommonContext):
             self.bean_patcher.update_tracker_text()
             aw_settings = get_settings().animal_well_settings
             if aw_settings.get("in_game_tracker", AWSettings.TrackerSetting.full_tracker) > AWSettings.TrackerSetting.no_tracker:
-                # self.bean_patcher.apply_tracker_patches()
+                self.bean_patcher.apply_tracker_patches()
                 pass
             else:
                 self.bean_patcher.revert_tracker_patches()
@@ -1423,8 +1422,7 @@ async def get_animal_well_process_handle(ctx: AnimalWellContext):
             host = get_settings()
             tracker_enum = AWSettings.TrackerSetting
             if host.animal_well_settings["in_game_tracker"] > tracker_enum.no_tracker:
-                pass
-                # ctx.bean_patcher.apply_tracker_patches()
+                ctx.bean_patcher.apply_tracker_patches()
             else:
                 ctx.bean_patcher.revert_tracker_patches()
 


### PR DESCRIPTION
## What is this fixing or adding?
This PR switches all of BeanPatcher to find the AW addresses by searching for AoB patterns, rather than using hard-coded offsets  that have to be updated manually with each patch or hotfix. This should future-proof the client, assuming none of the functions that we care about get modified.

## How was this tested?
Multiple users did completed runs with this branch.

## If this makes graphical changes, please attach screenshots.
