### PR TITLE
Candles: some locations are not candles

### DIFF
--- a/worlds/animal_well/client/client.py
+++ b/worlds/animal_well/client/client.py
@@ -25,7 +25,7 @@ from ..locations import location_name_to_id, location_table, events_table, ByteS
 from ..names import ItemNames as iname, LocationNames as lname
 from ..options import FinalEggLocation, Goal
 from ..client.bean_patcher import BeanPatcher
-from ..client.logic_tracker import AnimalWellTracker, CheckStatus, candle_event_to_item
+from ..client.logic_tracker import AnimalWellTracker, CheckStatus, candle_event_to_item, candle_locations
 
 CONNECTION_ABORTED_STATUS = "Connection Aborted. Some unrecoverable error occurred."
 CONNECTION_REFUSED_STATUS = ("Connection Refused. Likely causes are your game not "
@@ -611,10 +611,10 @@ class AnimalWellContext(CommonContext):
                                                   and location_name_to_id[k] in self.missing_locations})
         if self.slot_data.get("candle_checks", None):
             self.bean_patcher.tracker_candles = len({k: v for (k, v) in self.logic_tracker.check_logic_status.items()
-                                                     if "Candle" in k and "Event" not in k and v == CheckStatus.checked})
+                                                     if k in candle_locations and v == CheckStatus.checked})
         else:
             self.bean_patcher.tracker_candles = len({k: v for (k, v) in self.logic_tracker.check_logic_status.items()
-                                                     if "Candle" in k and "Event" in k and v == CheckStatus.checked})
+                                                     if k in candle_event_to_item and v == CheckStatus.checked})
         self.bean_patcher.update_tracker_text()
 
     def check_if_in_game(self) -> bool:

--- a/worlds/animal_well/client/logic_tracker.py
+++ b/worlds/animal_well/client/logic_tracker.py
@@ -33,6 +33,19 @@ candle_event_to_item: Dict[str, str] = {
 }
 
 
+candle_locations: Set[str] = {
+    lname.candle_first,
+    lname.candle_dog_dark,
+    lname.candle_dog_switch_box,
+    lname.candle_dog_many_switches,
+    lname.candle_dog_disc_switches,
+    lname.candle_dog_bat,
+    lname.candle_fish,
+    lname.candle_frog,
+    lname.candle_bear,
+}
+
+
 class AnimalWellTracker:
     player_options: Dict[str, int] = {
         Goal.internal_name: 0,


### PR DESCRIPTION
## What is this fixing or adding?

The in-game map tracker would show 2/9 candles when I cannot light any, or 11/9 after I've gotten them all. Upon review, the number is a count of all checked locations with "Candle" and not "Event" in the name, but these are not candles:
- Pink Fruit by Penguin Candle Top - R10C4a
- Blue Fruit by Penguin Candle Bottom - R10C4b
- Light All Candles

## How was this tested?

Connected to my current async game and verified the map tracker now shows 0/9 instead of 2/9.
