### PR TITLE
Animal Well: Improve the display of hints in-game

### DIFF
--- a/worlds/animal_well/client/client.py
+++ b/worlds/animal_well/client/client.py
@@ -400,11 +400,22 @@ class AnimalWellContext(CommonContext):
                     text = args.get("data")[0]["text"]
                     self.display_text_in_client(f"{text}")
                 elif msg_type == "Hint":
-                    if args.get("receiving") == self.slot:
+                    if self.slot_concerns_self(args.get("receiving")):
                         player_slot = args.get("item").player
                         item_name = self.item_names.lookup_in_slot(args.get("item").item, self.slot)
                         location_name = self.location_names.lookup_in_slot(args.get("item").location, player_slot)
-                        text = f"Hint: Your {item_name} is at {location_name}."
+                        if not self.slot_concerns_self(player_slot):
+                            player_name = self.player_names.get(player_slot)
+                            text = f"Hint: Your {item_name} is at {location_name} in {player_name}'s World."
+                        else:
+                            text = f"Hint: Your {item_name} is at your {location_name}."
+                        self.display_text_in_client(text)
+                    elif args.get("item").player == self.slot:
+                        receiving_player_slot = args.get("receiving")
+                        player_name = self.player_names.get(receiving_player_slot)
+                        item_name = self.item_names.lookup_in_slot(args.get("item").item, receiving_player_slot)
+                        location_name = self.location_names.lookup_in_slot(args.get("item").location, self.slot)
+                        text = f"Hint: {player_name}'s {item_name} is at your {location_name}."
                         self.display_text_in_client(text)
                 elif msg_type == "Join":
                     self.display_text_in_client(args.get("data")[0]["text"])


### PR DESCRIPTION
## What is this fixing or adding?
Improve displaying of hints to reflect WHOSE world the location is, and to let through hints where the current player's world is where a particular item is, since those are relevant for the current user as well.

## How was this tested?
Tested via triggering hints of all three relevant types:
- Your item in someone else's world.
- Your item in your OWN world.
- Someone else's item in your world.

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/user-attachments/assets/fa32f237-1917-40b6-af9c-2d99e12ffbc3)
![image](https://github.com/user-attachments/assets/d87a9016-d6c1-46cf-9728-500fb92a0276)
![image](https://github.com/user-attachments/assets/77d8c414-cd9c-4649-b71e-207ae598f064)
