### PR TITLE
Animal Well: Add options to pacify or disable ghost dog

### DIFF
--- a/worlds/animal_well/client/bean_patcher.py
+++ b/worlds/animal_well/client/bean_patcher.py
@@ -372,7 +372,8 @@ class BeanPatcher:
         self.ghost_disable_moaning_patch: Optional[Patch] = None
         self.ghost_disable_contact_damage_patch: Optional[Patch] = None
         self.no_dog_patch: Optional[Patch] = None
-
+        self.immediately_spawn_dog_patch: Optional[Patch] = None
+        self.prevent_despawning_dog_patch: Optional[Patch] = None
         self.cmd_prompt = False
         self.cmd = ""
         self.cmd_ready = False
@@ -1345,7 +1346,7 @@ class BeanPatcher:
         # spawn_ghost_dog_address = self.find_pattern("c7 45 00 01 00 00 00 4c 8b 15 3f b3 c2 02 45 8b 82 f8 8d 0a 00 31 c9 45 85 c0") + 3
         # self.no_ghost_patch = Patch("no_ghost", spawn_ghost_dog_address, self.process).add_bytes(b"\x00")
 
-        spawn_ghost_dog_address = self.find_pattern("c7 45 00 01 00 00 00 4c 8b 15 3f b3 c2 02 45 8b 82 f8 8d 0a 00 31 c9 45 85 c0")
+        spawn_ghost_dog_address = self.find_pattern("c7 45 0c 00 00 00 00 c7 45 00 01 00 00 00") + 7
         self.no_dog_patch = Patch("no_dog", spawn_ghost_dog_address, self.process).nop(7)
 
         if self.log_debug_info:

--- a/worlds/animal_well/client/client.py
+++ b/worlds/animal_well/client/client.py
@@ -105,6 +105,12 @@ class AnimalWellCommandProcessor(ClientCommandProcessor):
                 logger.info(f"Enabling goodboy...")
                 self.ctx.bean_patcher.enable_goodboy()
 
+    def _cmd_gooddog(self, val=""):
+        """
+        Alias for /goodboy
+        """
+        self._cmd_goodboy(val)
+
     def _cmd_nodog(self, val=""):
         """
         Disables ghost dog entirely
@@ -119,6 +125,12 @@ class AnimalWellCommandProcessor(ClientCommandProcessor):
                 logger.info(f"Enabling no_dog...")
                 self.ctx.bean_patcher.enable_no_dog()
 
+    def _cmd_noghost(self, val=""):
+        """
+        Alias for /nodog
+        """
+        self._cmd_nodog(val)
+
     def _cmd_alwaysdog(self, val=""):
         """
         Ghost dog hunts you eternally
@@ -132,6 +144,12 @@ class AnimalWellCommandProcessor(ClientCommandProcessor):
             else:
                 logger.info(f"Enabling always_dog...")
                 self.ctx.bean_patcher.enable_always_dog()
+
+    def _cmd_alwaysghost(self, val=""):
+        """
+        Alias for /alwaysdog
+        """
+        self._cmd_alwaysdog(val)
 
     def _cmd_deathlink(self, val=""):
         """

--- a/worlds/animal_well/client/client.py
+++ b/worlds/animal_well/client/client.py
@@ -105,19 +105,33 @@ class AnimalWellCommandProcessor(ClientCommandProcessor):
                 logger.info(f"Enabling goodboy...")
                 self.ctx.bean_patcher.enable_goodboy()
 
-    def _cmd_noghost(self, val=""):
+    def _cmd_nodog(self, val=""):
         """
         Disables ghost dog entirely
         """
         if isinstance(self.ctx, AnimalWellContext):
             if val == "":
-                self.ctx.bean_patcher.toggle_no_ghost()
+                self.ctx.bean_patcher.toggle_no_dog()
             elif val == "off":
-                logger.info(f"Disabling no_ghost...")
-                self.ctx.bean_patcher.disable_no_ghost()
+                logger.info(f"Disabling no_dog...")
+                self.ctx.bean_patcher.disable_no_dog()
             else:
-                logger.info(f"Enabling no_ghost...")
-                self.ctx.bean_patcher.enable_no_ghost()
+                logger.info(f"Enabling no_dog...")
+                self.ctx.bean_patcher.enable_no_dog()
+
+    def _cmd_alwaysdog(self, val=""):
+        """
+        Ghost dog hunts you eternally
+        """
+        if isinstance(self.ctx, AnimalWellContext):
+            if val == "":
+                self.ctx.bean_patcher.toggle_always_dog()
+            elif val == "off":
+                logger.info(f"Disabling always_dog...")
+                self.ctx.bean_patcher.disable_always_dog()
+            else:
+                logger.info(f"Enabling always_dog...")
+                self.ctx.bean_patcher.enable_always_dog()
 
     def _cmd_deathlink(self, val=""):
         """

--- a/worlds/animal_well/client/client.py
+++ b/worlds/animal_well/client/client.py
@@ -105,6 +105,20 @@ class AnimalWellCommandProcessor(ClientCommandProcessor):
                 logger.info(f"Enabling goodboy...")
                 self.ctx.bean_patcher.enable_goodboy()
 
+    def _cmd_noghost(self, val=""):
+        """
+        Disables ghost dog entirely
+        """
+        if isinstance(self.ctx, AnimalWellContext):
+            if val == "":
+                self.ctx.bean_patcher.toggle_no_ghost()
+            elif val == "off":
+                logger.info(f"Disabling no_ghost...")
+                self.ctx.bean_patcher.disable_no_ghost()
+            else:
+                logger.info(f"Enabling no_ghost...")
+                self.ctx.bean_patcher.enable_no_ghost()
+
     def _cmd_deathlink(self, val=""):
         """
         Toggles deathlink.

--- a/worlds/animal_well/client/client.py
+++ b/worlds/animal_well/client/client.py
@@ -91,6 +91,20 @@ class AnimalWellCommandProcessor(ClientCommandProcessor):
                 logger.info(f"Enabling fullbright...")
                 self.ctx.bean_patcher.enable_fullbright()
 
+    def _cmd_goodboy(self, val=""):
+        """
+        Disables ghost dog contact damage and the looping sound that plays while it's aggro
+        """
+        if isinstance(self.ctx, AnimalWellContext):
+            if val == "":
+                self.ctx.bean_patcher.toggle_goodboy()
+            elif val == "off":
+                logger.info(f"Disabling goodboy...")
+                self.ctx.bean_patcher.disable_goodboy()
+            else:
+                logger.info(f"Enabling goodboy...")
+                self.ctx.bean_patcher.enable_goodboy()
+
     def _cmd_deathlink(self, val=""):
         """
         Toggles deathlink.

--- a/worlds/animal_well/client/patch.py
+++ b/worlds/animal_well/client/patch.py
@@ -366,6 +366,15 @@ class Patch:
         self.add_bytes(b'\x0f\x87' + diff.to_bytes(4, 'little'))
         return self
 
+    def jmp_short_offset(self, offset):
+        """
+        Jumps a specific number of bytes from the NEXT instruction
+        2 bytes
+        """
+        diff = offset
+        self.add_bytes(b'\xeb' + diff.to_bytes(4, 'little', signed=True))
+        return self
+
     def jmp_near_offset(self, offset):
         """
         Jumps a specific number of bytes from the NEXT instruction


### PR DESCRIPTION
Marked as a draft until I add a persistence to this option, so you don't have to manually trigger it every time you play.

## What is this fixing or adding?
Adds three new commands. 
 - `/gooddog [on|off]`, `/goodboy [on|off]`: Disables the ghost dog's moaning sound, and removes its contact damage, rendering it a peaceful, mostly adorable companion.
 - `/nodog [on|off]`, `/noghost [on|off]`: Completely disables the ghost dog.
 - `/alwaysdog [on|off]`, `/alwaysghost [on|off]`: Forces ghost dog to hunt you regardless of disc state.
 
Note: NoDog and AlwaysDog are exclusive, and will disable each other so only one is active at once.

## How was this tested?

## If this makes graphical changes, please attach screenshots.
