### PR TITLE
additional bear middle phone + match spot connections

### DIFF
--- a/worlds/animal_well/region_data.py
+++ b/worlds/animal_well/region_data.py
@@ -538,6 +538,7 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         # shoot some hoops! throw the ball to the button. can be done without vertical if you throw early
         rname.bear_match_chest_spot:
             AWData(AWType.region, [[iname.ball_trick_medium], [iname.bubble, iname.tanking_damage],
+                                   [iname.bubble_long_real, iname.lantern],
                                    [iname.disc, iname.tanking_damage, iname.precise_tricks],
                                    [iname.wheel_climb, iname.tanking_damage]]),
         rname.bear_chameleon_room_2:
@@ -598,6 +599,11 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
                                    # throw the ball in the yoyo pipe then run left with yoyo or slink
                                    [iname.slink, iname.ball_trick_easy],
                                    [iname.yoyo, iname.ball_trick_easy]]),
+        rname.bear_middle_phone_room:
+            AWData(AWType.region, [[iname.bubble, iname.tanking_damage],
+                                   [iname.bubble_long_real, iname.lantern],
+                                   [iname.disc, iname.tanking_damage, iname.precise_tricks],
+                                   [iname.wheel_climb, iname.tanking_damage]]),
     },
     rname.bear_upper_phone_room: {
         lname.fruit_8:


### PR DESCRIPTION
## What is this fixing or adding?

Every trick that can be done to get over the bear match door can also be done in reverse.
Additionally, we now also accommodate for the possibility of getting over the wall damageless with real BBWand + Lantern.

## How was this tested?

It wasn't

## If this makes graphical changes, please attach screenshots.
