### PR TITLE
Discord Logic Updates as of 7/31/25

### DIFF
--- a/worlds/animal_well/region_data.py
+++ b/worlds/animal_well/region_data.py
@@ -801,7 +801,7 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         lname.fruit_3:
             AWData(AWType.location, [[iname.top]], loc_type=LocType.fruit),
         lname.egg_brown:
-            AWData(AWType.location, [[iname.slink]]),
+            AWData(AWType.location, [[iname.slink], [iname.ball_trick_hard]]),
         lname.fruit_2:
             AWData(AWType.location, loc_type=LocType.fruit),
         lname.egg_reference:  # funny slink and disc room

--- a/worlds/animal_well/region_data.py
+++ b/worlds/animal_well/region_data.py
@@ -1216,10 +1216,10 @@ traversal_requirements: Dict[Union[lname, rname], Dict[Union[lname, rname], AWDa
         lname.fruit_105:
             AWData(AWType.location, [[iname.bubble, iname.top, iname.wheel], [iname.disc, iname.top, iname.wheel],
                                      [iname.wheel_hop, iname.top]], loc_type=LocType.fruit),
-        rname.hippo_fireworks:  # todo: verify you need disc
-            AWData(AWType.region, [[iname.slink, iname.yoyo, iname.disc]]),
+        rname.hippo_fireworks:  # If you pre-hold the button, top can push the button incidentally enough to get you through
+            AWData(AWType.region, [[iname.slink, iname.yoyo, iname.disc], [iname.top, iname.yoyo, iname.disc, iname.obscure_tricks]]),
         rname.hippo_skull_room:
-            AWData(AWType.region, [[iname.slink, iname.yoyo, iname.disc]]),
+            AWData(AWType.region, [[iname.slink, iname.yoyo, iname.disc], [iname.top, iname.yoyo, iname.disc, iname.obscure_tricks]]),
     },
     rname.hippo_skull_room: {
         lname.bb_wand_chest:


### PR DESCRIPTION
> Access to Brown Egg chest with expert ball tricks
> Clear Manticore Arena room without using slink on the stairs. Self-press the button, then use top to add enough total press time that you can squeeze under the falling block. It's nominally possible to do with yoyo as well but I wasn't able to consistently perform it (and it seems tight as is) so I think we can reconsider it at another time.